### PR TITLE
Fix: fixed marker direction rendering location.

### DIFF
--- a/Umbra/src/Markers/Renderer/WorldMarkerDirectionRenderer.cs
+++ b/Umbra/src/Markers/Renderer/WorldMarkerDirectionRenderer.cs
@@ -81,13 +81,14 @@ public sealed class WorldMarkerDirectionRenderer(
         gameGui.WorldToScreen(playerPos, out var center);
 
         var cos = MathF.Cos(angle);
-        var addX = cos > 0 ? cos * (xMax - center.X) : cos * (center.X - xMin);
-
+        var xRange = cos > 0 ? (xMax - center.X) : (center.X - xMin);
         var sin = MathF.Sin(angle);
-        var addY = sin > 0 ? sin * (yMax - center.Y ) : sin * (center.Y - yMin);
+        var yRange = sin > 0 ? (yMax - center.Y) : (center.Y - yMin);
 
-        float x = center.X + addX;
-        float y = center.Y + addY;
+        var angleForPos = MathF.Atan2(sin * xRange, cos * yRange);
+
+        float x = center.X + MathF.Cos(angleForPos) * xRange;
+        float y = center.Y + MathF.Sin(angleForPos) * yRange;
 
         x = MathF.Min(MathF.Max(x, xMin), xMax);
         y = MathF.Min(MathF.Max(y, yMin), yMax);

--- a/Umbra/src/Markers/Renderer/WorldMarkerDirectionRenderer.cs
+++ b/Umbra/src/Markers/Renderer/WorldMarkerDirectionRenderer.cs
@@ -68,8 +68,24 @@ public sealed class WorldMarkerDirectionRenderer(
 
         // Move the marker to the edge of the screen.
         float dX = UseCircularPositioning ? displaySize.Y : displaySize.X;
-        float x  = displayPos.X + (displaySize.X / 2 + MathF.Cos(angle) * ((dX / 2) - Radius));
-        float y  = displayPos.Y + (displaySize.Y / 2 + MathF.Sin(angle) * ((displaySize.Y / 2) - Radius));
+        float dY = displaySize.Y;
+
+        gameGui.WorldToScreen(playerPos, out var center);
+
+        var cos = MathF.Cos(angle);
+        var addX = cos > 0 ? cos * (dX - center.X - Radius) : cos * (center.X - Radius);
+
+        var sin = MathF.Sin(angle);
+        var addY = sin > 0 ? sin * (dY - center.Y - Radius) : sin * (center.Y - Radius);
+
+        float x = center.X + addX;
+        float y = center.Y + addY;
+
+        x = MathF.Min(MathF.Max(x, Radius), dX - Radius);
+        y = MathF.Min(MathF.Max(y, Radius), dY - Radius);
+
+        x += displayPos.X;
+        y += displayPos.Y;
 
         var bounds = new Rect(new(x - (wSize / 2), y - (wSize / 2)), new(x + (wSize / 2), y + (wSize / 2)));
 

--- a/Umbra/src/Markers/Renderer/WorldMarkerDirectionRenderer.cs
+++ b/Umbra/src/Markers/Renderer/WorldMarkerDirectionRenderer.cs
@@ -70,19 +70,27 @@ public sealed class WorldMarkerDirectionRenderer(
         float dX = UseCircularPositioning ? displaySize.Y : displaySize.X;
         float dY = displaySize.Y;
 
+        dX = dX / 2 - Radius;
+        dY = dY / 2 - Radius;
+
+        var xMin = displaySize.X / 2 - dX;
+        var xMax = displaySize.X / 2 + dX;
+        var yMin = displaySize.Y / 2 - dY;
+        var yMax = displaySize.Y / 2 + dY;
+
         gameGui.WorldToScreen(playerPos, out var center);
 
         var cos = MathF.Cos(angle);
-        var addX = cos > 0 ? cos * (dX - center.X - Radius) : cos * (center.X - Radius);
+        var addX = cos > 0 ? cos * (xMax - center.X) : cos * (center.X - xMin);
 
         var sin = MathF.Sin(angle);
-        var addY = sin > 0 ? sin * (dY - center.Y - Radius) : sin * (center.Y - Radius);
+        var addY = sin > 0 ? sin * (yMax - center.Y ) : sin * (center.Y - yMin);
 
         float x = center.X + addX;
         float y = center.Y + addY;
 
-        x = MathF.Min(MathF.Max(x, Radius), dX - Radius);
-        y = MathF.Min(MathF.Max(y, Radius), dY - Radius);
+        x = MathF.Min(MathF.Max(x, xMin), xMax);
+        y = MathF.Min(MathF.Max(y, yMin), yMax);
 
         x += displayPos.X;
         y += displayPos.Y;


### PR DESCRIPTION
Some players may change the value `3rd Person Camera Angle` or use the plugin [Cammy](https://github.com/UnknownX7/Cammy) to make their character not in the center of the screen.

This change mainly ensures that the Direction Render is more accurate in this situation.