### PR TITLE
Fix title for inactive toolbar theming

### DIFF
--- a/Umbra/i18n/en.json
+++ b/Umbra/i18n/en.json
@@ -637,7 +637,7 @@
     "Color.Toolbar.Border.Description": "The border color of the toolbar.",
     "Color.Toolbar.InactiveBackground1.Name": "Toolbar inactive background 1",
     "Color.Toolbar.InactiveBackground1.Description": "The first background color of the toolbar in an inactive state.",
-    "Color.Toolbar.InactiveBackground2.Name": "Toolbar background 2",
+    "Color.Toolbar.InactiveBackground2.Name": "Toolbar inactive background 2",
     "Color.Toolbar.InactiveBackground2.Description": "The second background color of the toolbar in an inactive state.",
     "Color.Toolbar.InactiveBorder.Name": "Toolbar inactive border",
     "Color.Toolbar.InactiveBorder.Description": "The border color of the toolbar in an inactive state.",


### PR DESCRIPTION
Edit the text regarding the 2nd toolbar inactive background color to clarify it's for the inactive state, just like the 1st toolbar as it currently uses the same title as the active state.
![image](https://github.com/una-xiv/umbra/assets/153868115/9fa2d48f-7de8-457f-9c20-60c1430cd2c7)
