### PR TITLE
Remove discontinued scrips from enum

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/Currencies/CurrenciesWidget.Data.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Currencies/CurrenciesWidget.Data.cs
@@ -180,8 +180,8 @@ internal partial class CurrenciesWidget
         TrophyCrystals       = 36656,
         PurpleCrafterScrips  = 33913,
         PurpleGathererScrips = 33914,
-        WhiteCrafterScrips   = 25199, // (Discontinued)
-        WhiteGathererScrips  = 25200, // (Discontinued)
+        //WhiteCrafterScrips   = 25199, // (Discontinued)
+        //WhiteGathererScrips  = 25200, // (Discontinued)
         OrangeCrafterScrips  = 41784,
         OrangeGathererScrips = 41785,
         SkyBuildersScrips    = 28063,


### PR DESCRIPTION
Leaving the discontinued scrips in the enum in e2b5aed in response to #113 (unlike what was done with discontinued tomestones) means that they cannot be used in the Custom ID List:
> [Umbra] Custom currency id 25199 is already defined in CurrencyType enum.

This simply comments them out of the enum so they can appear via the Custom ID List (ie, track how many you have left to convert).