### PR TITLE
Swap Dalamud Plugins and Settings buttons in the main menu

### DIFF
--- a/Umbra.Game/src/MainMenu/MainMenuRepository.cs
+++ b/Umbra.Game/src/MainMenu/MainMenuRepository.cs
@@ -91,9 +91,11 @@ internal sealed class MainMenuRepository : IMainMenuRepository
 
         Categories[MenuCategory.System].AddItem(new(-1000));
 
+        
+
         Categories[MenuCategory.System]
             .AddItem(
-                new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudSettings"), 1001, "/xlsettings") {
+                new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudPlugins"), 1001, "/xlplugins") {
                     Icon           = SeIconChar.BoxedLetterD,
                     IconColor      = 0xFF5151FF,
                     ItemGroupId    = "Dalamud",
@@ -103,7 +105,7 @@ internal sealed class MainMenuRepository : IMainMenuRepository
 
         Categories[MenuCategory.System]
             .AddItem(
-                new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudPlugins"), 1002, "/xlplugins") {
+                new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudSettings"), 1002, "/xlsettings") {
                     Icon           = SeIconChar.BoxedLetterD,
                     IconColor      = 0xFF5151FF,
                     ItemGroupId    = "Dalamud",

--- a/Umbra.Game/src/MainMenu/MainMenuRepository.cs
+++ b/Umbra.Game/src/MainMenu/MainMenuRepository.cs
@@ -91,8 +91,6 @@ internal sealed class MainMenuRepository : IMainMenuRepository
 
         Categories[MenuCategory.System].AddItem(new(-1000));
 
-        
-
         Categories[MenuCategory.System]
             .AddItem(
                 new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudPlugins"), 1001, "/xlplugins") {


### PR DESCRIPTION
This change swaps the Dalamud Plugins and Dalamud Settings buttons around in the main menu widget to be more consistent with the esc menu.