### PR TITLE
Make Durability widget get checked during pvp too

### DIFF
--- a/Umbra.Game/src/MainMenu/MainMenuRepository.cs
+++ b/Umbra.Game/src/MainMenu/MainMenuRepository.cs
@@ -91,9 +91,11 @@ internal sealed class MainMenuRepository : IMainMenuRepository
 
         Categories[MenuCategory.System].AddItem(new(-1000));
 
+        
+
         Categories[MenuCategory.System]
             .AddItem(
-                new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudSettings"), 1001, "/xlsettings") {
+                new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudPlugins"), 1001, "/xlplugins") {
                     Icon           = SeIconChar.BoxedLetterD,
                     IconColor      = 0xFF5151FF,
                     ItemGroupId    = "Dalamud",
@@ -103,7 +105,7 @@ internal sealed class MainMenuRepository : IMainMenuRepository
 
         Categories[MenuCategory.System]
             .AddItem(
-                new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudPlugins"), 1002, "/xlplugins") {
+                new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudSettings"), 1002, "/xlsettings") {
                     Icon           = SeIconChar.BoxedLetterD,
                     IconColor      = 0xFF5151FF,
                     ItemGroupId    = "Dalamud",

--- a/Umbra.Game/src/MainMenu/MainMenuRepository.cs
+++ b/Umbra.Game/src/MainMenu/MainMenuRepository.cs
@@ -91,8 +91,6 @@ internal sealed class MainMenuRepository : IMainMenuRepository
 
         Categories[MenuCategory.System].AddItem(new(-1000));
 
-        
-
         Categories[MenuCategory.System]
             .AddItem(
                 new(I18N.Translate("Widget.MainMenu.CustomItem.DalamudPlugins"), 1001, "/xlplugins") {

--- a/Umbra.Game/src/Player/Equipment/EquipmentRepository.cs
+++ b/Umbra.Game/src/Player/Equipment/EquipmentRepository.cs
@@ -71,9 +71,6 @@ internal unsafe class EquipmentRepository : IEquipmentRepository, IDisposable
     [OnTick(interval: 1000)]
     public void Update()
     {
-        // Scanning while in PvP is useless, as gear is locked.
-        if (_isInPvP) return;
-
         ushort lowestDurability  = ushort.MaxValue;
         ushort highestSpiritbond = 0;
 


### PR DESCRIPTION
- This change allows the Durability widget to update while PvP is enabled too, as while durability can indeed not go down during PvP, it does break when the user repairs their gear

- May possibly be worth removing the other pvp strings in this file but I locally removed too much and it kept giving build errors so this will do for now