### PR TITLE
Modify condition determining chocobo companion summoning

### DIFF
--- a/Umbra.Game/src/Companion/CompanionManager.cs
+++ b/Umbra.Game/src/Companion/CompanionManager.cs
@@ -97,7 +97,7 @@ internal sealed class CompanionManager : ICompanionManager
     public bool CanSummon()
     {
         return HasGysahlGreens
-            && _player is { IsBoundByDuty: false, IsOccupied: false, IsCasting: false, IsDead: false };
+            && _player is { IsBoundByInstancedDuty: false, IsOccupied: false, IsCasting: false, IsDead: false };
     }
 
     public void Summon()

--- a/Umbra.Game/src/Player/IPlayer.cs
+++ b/Umbra.Game/src/Player/IPlayer.cs
@@ -111,6 +111,11 @@ public interface IPlayer
     public bool IsBoundByDuty { get; }
 
     /// <summary>
+    /// True if the player is currently bound by duty in an instance.
+    /// </summary>
+    public bool IsBoundByInstancedDuty { get; }
+
+    /// <summary>
     /// True if the player is currently occupied in a quest event.
     /// </summary>
     public bool IsInQuestEvent { get; }

--- a/Umbra.Game/src/Player/Player.cs
+++ b/Umbra.Game/src/Player/Player.cs
@@ -123,6 +123,11 @@ internal sealed class Player : IPlayer
     public bool IsBoundByDuty { get; private set; }
 
     /// <summary>
+    /// True if the player is currently bound by duty in an instance.
+    /// </summary>
+    public bool IsBoundByInstancedDuty { get; private set; }
+
+    /// <summary>
     /// True if the player is currently occupied in a quest event.
     /// </summary>
     public bool IsInQuestEvent { get; private set; }
@@ -245,6 +250,8 @@ internal sealed class Player : IPlayer
         IsBoundByDuty = _condition[ConditionFlag.BoundByDuty]
             || _condition[ConditionFlag.BoundByDuty56]
             || _condition[ConditionFlag.BoundByDuty95];
+
+        IsBoundByInstancedDuty = _condition[ConditionFlag.BoundByDuty56];
 
         IsInCutscene = _condition[ConditionFlag.OccupiedInCutSceneEvent]
             || _condition[ConditionFlag.WatchingCutscene]


### PR DESCRIPTION
The `IsBoundByDuty` flag uses multiple condition flags, which prevents the summoning of the companion in overworld duties. The condition flag `BoundByDuty56` is common to instanced duties, and so can be used to differentiate the two. I created a new flag specifically for the companion widget, to be used in place of the previous one. The previous flag still exists as it is currently in use in other widgets.

Note that I have tested as many duties as feasible, with the exception of solo instance battles (no currently playable content on my end).