### PR TITLE
Implement IDisposable for WindowManager and Window

### DIFF
--- a/Umbra/src/Windows/System/Manager/WindowManager.cs
+++ b/Umbra/src/Windows/System/Manager/WindowManager.cs
@@ -21,13 +21,21 @@ using Umbra.Common;
 namespace Umbra.Windows;
 
 [Service]
-internal class WindowManager
+internal class WindowManager : IDisposable
 {
     public event Action<Window>? OnWindowOpened;
     public event Action<Window>? OnWindowClosed;
 
     private readonly Dictionary<string, Window>          _instances = [];
     private readonly Dictionary<string, Action<Window>?> _callbacks = [];
+
+    public void Dispose()
+    {
+        foreach (var win in _instances.Values)
+            win.Dispose();
+
+        _instances.Clear();
+    }
 
     /// <summary>
     /// Presents a window and invokes the given callback once the window is

--- a/Umbra/src/Windows/System/Window/Window.cs
+++ b/Umbra/src/Windows/System/Window/Window.cs
@@ -19,7 +19,7 @@ using Una.Drawing;
 
 namespace Umbra.Windows;
 
-internal abstract partial class Window
+internal abstract partial class Window : IDisposable
 {
     internal event Action? RequestClose;
 
@@ -45,7 +45,7 @@ internal abstract partial class Window
     /// </summary>
     protected abstract void OnClose();
 
-    ~Window()
+    public void Dispose()
     {
         _windowNode.Dispose();
         Node.Dispose();


### PR DESCRIPTION
To make sure Nodes are disposed, we have to dispose WindowManager and its Windows first.