### PR TITLE
Allow plugins to reference other assemblies

### DIFF
--- a/Umbra/src/Plugins/PluginLoadContext.cs
+++ b/Umbra/src/Plugins/PluginLoadContext.cs
@@ -84,7 +84,7 @@ internal class PluginLoadContext(DirectoryInfo directoryInfo) : AssemblyLoadCont
         if (!file.Exists) return base.Load(assemblyName);
 
         try {
-            return LoadFromFile(file.FullName);
+            return LoadFromFileInternal(file.FullName);
         } catch (Exception e) {
             Logger.Error($"Failed to load {assemblyName.Name} from {file.FullName}: {e.Message}");
         }


### PR DESCRIPTION
I ran into an issue where Umbra refused to load a plugin with a reference to a second assembly.

It looks like Umbra's custom `AssemblyLoadContext` currently requires every assembly it loads to be an Umbra plugin or one of a few recognized assemblies, so plugins with other dependencies don't work. This change makes Umbra validate only the plugin assembly itself.

I'm not sure if this change has any side effects, but it has been working for me locally.
