### PR TITLE
Societal Relation max rank fix #4

### DIFF
--- a/Umbra.Game/src/Player/Societies/Society.cs
+++ b/Umbra.Game/src/Player/Societies/Society.cs
@@ -22,9 +22,9 @@ public struct Society
     public uint   ExpansionId    { get; init; }
     public string ExpansionName  { get; init; }
     public string Name           { get; init; }
-    public uint   RankId         { get; init; }
+    public uint   Rank           { get; init; }
     public byte   MaxRank        { get; init; }
-    public string Rank           { get; init; }
+    public string RankName       { get; init; }
     public uint   RankColor      { get; init; }
     public uint   IconId         { get; init; }
     public uint   CurrencyItemId { get; init; }

--- a/Umbra/src/Toolbar/Widgets/Library/Societies/SocietiesWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Societies/SocietiesWidget.cs
@@ -54,9 +54,9 @@ internal sealed partial class SocietiesWidget(
 
             string rep = pct is < 100 and > 0 ? $" ({pct}%)" : "";
 
-            SetTwoLabels(society.Value.Name, $"{society.Value.Rank}{rep}");
+            SetTwoLabels(society.Value.Name, $"{society.Value.RankName}{rep}");
             SetIcon(society.Value.IconId);
-            tooltip = $"{society.Value.Name} - {society.Value.Rank}{rep}";
+            tooltip = $"{society.Value.Name} - {society.Value.RankName}{rep}";
         }
 
         base.OnUpdate();

--- a/Umbra/src/Toolbar/Widgets/Library/Societies/SocietiesWidgetPopup.Nodes.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Societies/SocietiesWidgetPopup.Nodes.cs
@@ -78,7 +78,7 @@ internal sealed partial class SocietiesWidgetPopup
                         },
                         new() {
                             ClassList = ["society--rank"],
-                            NodeValue = $"{society.Rank}",
+                            NodeValue = $"{society.RankName}",
                             ChildNodes = [
                                 new() {
                                     ClassList = ["society--rank--value"],

--- a/Umbra/src/Toolbar/Widgets/Library/Societies/SocietiesWidgetPopup.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Societies/SocietiesWidgetPopup.cs
@@ -61,7 +61,7 @@ internal sealed partial class SocietiesWidgetPopup : WidgetPopup
         );
 
         foreach (Society society in Player.Societies.OrderBy(s => s.ExpansionId)) {
-            if (society.RankId == 0) continue;
+            if (society.Rank == 0) continue;
 
             Node expansionNode = GetOrCreateExpansionNodeFor(society.ExpansionId, society.ExpansionName);
             Node societyNode   = GetOrCreateSocietyNode(society, expansionNode);
@@ -76,7 +76,7 @@ internal sealed partial class SocietiesWidgetPopup : WidgetPopup
                 rankStr.AddUiForeground((ushort)society.RankColor);
             }
 
-            rankStr.AddText($"{society.Rank} ({society.RankId} / {society.MaxRank})");
+            rankStr.AddText($"{society.RankName} ({society.Rank} / {society.MaxRank})");
 
             societyNode.QuerySelector(".society--exp-bar--bar")!.Style.Size = new(expWidth, 2);
             societyNode.QuerySelector(".society--rank--value")!.NodeValue   = $"{expPct}%";


### PR DESCRIPTION
Tried to fix it by using the games code flow.

Rank 8 = Solidarisch★/Bloodsworn
If allied quest is complete, it increases rank to Rank 9 (except for ARR, which stays at Rank 8) and prints Verbündet/Allied

Still looking fine for me:
![Screenshot](https://github.com/user-attachments/assets/68bf87d2-67aa-4305-9bb5-b8fec7bc080b)

For testing, I set `rank = (byte)8` and it correctly prints out the rank names:
![Screenshot](https://github.com/user-attachments/assets/9c55d04c-f310-4488-a026-1c8c1223e548)
