### PR TITLE
DynamicMenuWidget: Append label to widget instance name

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/DynamicMenu/DynamicMenuWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/DynamicMenu/DynamicMenuWidget.cs
@@ -15,7 +15,12 @@ internal sealed partial class DynamicMenuWidget(
 ) : DefaultToolbarWidget(info, guid, configValues)
 {
     public override DynamicMenuPopup Popup { get; } = new();
-
+    
+    public override string GetInstanceName()
+    {
+        return $"{I18N.Translate("Widget.DynamicMenu.Name")} - {GetConfigValue<string>("ButtonLabel")}";
+    }
+    
     protected override void Initialize()
     {
         Popup.OnEditModeChanged += OnEditModeChanged;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/474336ca-e27f-40f4-8594-cb55385f7cf0)

This is easier to know which dynamic menu you are moving / removing