### PR TITLE
Add the ButtonLabel to the Dynamic Menu widget name

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/DynamicMenu/DynamicMenuWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/DynamicMenu/DynamicMenuWidget.cs
@@ -16,6 +16,12 @@ internal sealed partial class DynamicMenuWidget(
 {
     public override DynamicMenuPopup Popup { get; } = new();
 
+    /// <inheritdoc/>
+    public override string GetInstanceName()
+    {
+        return $"{I18N.Translate("Widget.DynamicMenu.Name")} - {GetConfigValue<string>("ButtonLabel")}";
+    }
+
     protected override void Initialize()
     {
         Popup.OnEditModeChanged += OnEditModeChanged;


### PR DESCRIPTION
This replicates what the Custom Menu does so you can tell what menu the item relates to.