### PR TITLE
Adding a progress bar component

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/Durability/DurabilityWidget.Nodes.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Durability/DurabilityWidget.Nodes.cs
@@ -1,4 +1,5 @@
-﻿using Una.Drawing;
+﻿using Umbra.Windows.Components;
+using Una.Drawing;
 
 namespace Umbra.Widgets;
 
@@ -7,35 +8,15 @@ internal partial class DurabilityWidget
 
     private Node BarWrapperNode = new() {
         Stylesheet = Stylesheet,
-        SortIndex = -1,
-        Id = "BarWrapper",
+        SortIndex  = 0,
+        Id         = "BarWrapper",
         ChildNodes = [
-            new() {
-                Id = "DurabilityBarContainer",
-                ClassList = ["bar-container"],
-                ChildNodes = [
-                    new() {
-                        Id = "DurabilityBar",
-                        ClassList = ["bar"]
-                    }
-                ]
-            },
-            new() {
-                Id = "SpiritbondBarContainer",
-                ClassList = ["bar-container"],
-                ChildNodes = [
-                    new() {
-                        Id = "SpiritbondBar",
-                        ClassList = ["bar"]
-                    }
-                ]
-            }
-        ]
+            new ProgressBarNode("SpiritbondBar"),
+            new ProgressBarNode("DurabilityBar"),
+        ],
     };
-    
-    private Node DurabilityBarNode          => Node.QuerySelector("#DurabilityBar")!;
-    private Node SpiritbondBarNode          => Node.QuerySelector("#SpiritbondBar")!;
-    private Node DurabilityBarContainerNode => Node.QuerySelector("#DurabilityBarContainer")!;
-    private Node SpiritbondBarContainerNode => Node.QuerySelector("#SpiritbondBarContainer")!;
+
+    private ProgressBarNode DurabilityBarNode => (ProgressBarNode)Node.QuerySelector("#DurabilityBar")!;
+    private ProgressBarNode SpiritbondBarNode => (ProgressBarNode)Node.QuerySelector("#SpiritbondBar")!;
 
 }

--- a/Umbra/src/Toolbar/Widgets/Library/Durability/DurabilityWidget.Stylesheet.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Durability/DurabilityWidget.Stylesheet.cs
@@ -11,54 +11,8 @@ internal partial class DurabilityWidget
             new () {
                 Flow         = Flow.Vertical,
                 Gap          = 1,
-                Padding      = new EdgeSize(2, 0)
+                Padding      = new EdgeSize(2, 0),
             }
         ),
-        new (
-            ".bar-container",
-            new () {
-                BorderRadius = 5
-            }
-        ),
-        new (
-            ".bar-container:bordered",
-            new () {
-                BackgroundColor = new("Widget.Background"),
-                StrokeColor     = new("Widget.Border"),
-                StrokeWidth     = 1,
-                StrokeInset     = 1,
-                BorderRadius    = 5,
-                StrokeRadius    = 4,
-                Padding         = new EdgeSize(2)
-            }
-        ),
-        new (
-            ".bar",
-            new () {
-                Size = new(0, 0),
-                BorderRadius = 3,
-                IsAntialiased = true
-            }
-        ),
-        new(
-            "#DurabilityBar",
-            new() {
-                BackgroundColor = new("Misc.DurabilityBar"),
-                Anchor = Anchor.BottomLeft
-            }
-        ),
-        new(
-            "#SpiritbondBar",
-            new() {
-                BackgroundColor = new("Misc.SpiritbondBar"),
-            }
-        ),
-        new(
-            "#SpiritbondBar:full",
-            new() {
-                BackgroundColor = new("Misc.CompleteSpiritbondBar"),
-            }
-        ),
-        
     ]);
 }

--- a/Umbra/src/Toolbar/Widgets/Library/Durability/DurabilityWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Durability/DurabilityWidget.cs
@@ -21,6 +21,7 @@ using Lumina.Excel.GeneratedSheets;
 using System;
 using Umbra.Common;
 using Umbra.Game;
+using Umbra.Windows.Components;
 using Una.Drawing;
 
 namespace Umbra.Widgets;
@@ -84,6 +85,9 @@ internal partial class DurabilityWidget(
             groupId: "Actions",
             onClick: () => Player.UseGeneralAction(13)
         );
+
+        // Use overflow to represent over repaired gear
+        DurabilityBarNode.UseOverflow = true;
     }
 
     /// <inheritdoc/>
@@ -297,56 +301,45 @@ internal partial class DurabilityWidget(
         }
     }
 
+
     private void UpdateBars(byte durability, byte spiritbond)
     {
-        bool useBorders  = GetConfigValue<bool>("UseBarBorder");
-        var  width       = GetConfigValue<int>("BarWidth");
-        var  height      = (int)Math.Ceiling(SafeHeight / 2f) - 3;
-        var  innerWidth  = width - (useBorders ? 4 : 2);
-        var  innerHeight = height - (useBorders ? 4 : 2);
+        var width  = GetConfigValue<int>("BarWidth");
+        var height = (int)Math.Ceiling(SafeHeight / 2f) - 3;
 
-        // Fix the width for the wrapper.
-        BarWrapperNode.Style.Size = new Size(width, SafeHeight);
+        // General look and feel of the bars
+        BarWrapperNode.Style.Size    = new(width, SafeHeight);
+        DurabilityBarNode.Style.Size = new(width, height);
+        SpiritbondBarNode.Style.Size = new(width, height);
+
+        DurabilityBarNode.BarNode.Style.BackgroundColor      = new("Misc.DurabilityBar");
+        DurabilityBarNode.OverflowNode.Style.BackgroundColor = new("Window.Text");
+        SpiritbondBarNode.BarNode.Style.BackgroundColor      = spiritbond == 100 ? new("Misc.CompleteSpiritbondBar") : new("Misc.SpiritbondBar");
 
         // Force the space for icon rendering, I don't like this :(
         LabelNode.Style.IsVisible = true;
-        LabelNode.Style.Size      = new Size(width, SafeHeight);
+        LabelNode.Style.Size      = new(width, SafeHeight);
 
         // Ensure wrapper offset depending on left icon visibility
         BarWrapperNode.Style.Margin = new EdgeSize(0, 0, 0, LeftIconNode.IsVisible ? LeftIconNode.Width : 0);
 
-        DurabilityBarContainerNode.Style.Size = new(width, height);
-        SpiritbondBarContainerNode.Style.Size = new(width, height);
+        DurabilityBarNode.UseBorder = GetConfigValue<bool>("UseBarBorder");
+        SpiritbondBarNode.UseBorder = GetConfigValue<bool>("UseBarBorder");
 
-        if (useBorders) {
-            DurabilityBarContainerNode.TagsList.Add("bordered");
-            SpiritbondBarContainerNode.TagsList.Add("bordered");
+        if (GetConfigValue<string>("BarDirection") == "R2L") {
+            DurabilityBarNode.Direction = ProgressBarNode.FillDirection.RightToLeft;
+            SpiritbondBarNode.Direction = ProgressBarNode.FillDirection.RightToLeft;
         } else {
-            DurabilityBarContainerNode.TagsList.Remove("bordered");
-            SpiritbondBarContainerNode.TagsList.Remove("bordered");
+            DurabilityBarNode.Direction = ProgressBarNode.FillDirection.LeftToRight;
+            SpiritbondBarNode.Direction = ProgressBarNode.FillDirection.LeftToRight;
         }
 
-        byte realDurabilityValue = Math.Min(durability, (byte)100);
-        byte realSpiritbondValue = Math.Min(spiritbond, (byte)100);
-
-        int durabilityBarWidth = (int)((realDurabilityValue / 100f) * innerWidth);
-        int spiritbondBarWidth = (int)((realSpiritbondValue / 100f) * innerWidth);
-
-        DurabilityBarNode.Style.Size = new(durabilityBarWidth, innerHeight);
-        SpiritbondBarNode.Style.Size = new(spiritbondBarWidth, innerHeight);
-
-        if (realSpiritbondValue == 100) {
-            SpiritbondBarNode.TagsList.Add("full");
-        } else {
-            SpiritbondBarNode.TagsList.Remove("full");
-        }
+        DurabilityBarNode.Value = durability;
+        SpiritbondBarNode.Value = spiritbond;
     }
 
     private void UseStackedBars()
     {
-        DurabilityBarContainerNode.Style.Margin = new EdgeSize(0, 0, 0, 0);
-        SpiritbondBarContainerNode.Style.Margin = new EdgeSize(0, 0, 0, 0);
-
         if (GetConfigValue<string>("BarDirection") == "R2L") {
             DurabilityBarNode.Style.Anchor = Anchor.BottomRight;
             SpiritbondBarNode.Style.Anchor = Anchor.BottomRight;
@@ -366,11 +359,11 @@ internal partial class DurabilityWidget(
         var width  = GetConfigValue<int>("BarWidth");
 
         // Ensure the gap between icons and opposite bars aren't too much
-        LabelNode.Style.Size      = new Size(width - margin, SafeHeight);
-        BarWrapperNode.Style.Size = new Size(width - margin, SafeHeight);
+        LabelNode.Style.Size      = new(width - margin, SafeHeight);
+        BarWrapperNode.Style.Size = new(width - margin, SafeHeight);
 
-        DurabilityBarContainerNode.Style.Margin = new EdgeSize(0, 0, 0, -margin);
-        SpiritbondBarContainerNode.Style.Margin = new EdgeSize(0, 0, 0, LeftIconNode.Width / 3);
+        DurabilityBarNode.Style.Margin = new EdgeSize(0, 0, 0, -margin);
+        SpiritbondBarNode.Style.Margin = new EdgeSize(0, 0, 0, LeftIconNode.Width / 3);
 
         DurabilityBarNode.Style.Anchor = Anchor.BottomLeft;
         SpiritbondBarNode.Style.Anchor = Anchor.BottomRight;

--- a/Umbra/src/Windows/Components/ProgressBarNode.cs
+++ b/Umbra/src/Windows/Components/ProgressBarNode.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using Umbra.Common;
+using Una.Drawing;
+
+namespace Umbra.Windows.Components;
+
+public class ProgressBarNode : Node
+{
+    private const int PaddingSize = 2;
+
+    public Node BarNode { get; } = new() {
+        ClassList   = ["bar", "bar--current-value"],
+        InheritTags = true,
+    };
+
+    public Node OverflowNode { get; } = new() {
+        ClassList   = ["bar", "bar--overflow-value"],
+        InheritTags = true,
+    };
+
+    /// <summary>
+    /// Minimum value allowed on this bar
+    /// </summary>
+    public int Minimum { get; set; } = 0;
+
+    /// <summary>
+    /// Maximum value allowed on this bar
+    /// </summary>
+    public int Maximum { get; set; } = 100;
+
+    /// <summary>
+    /// Current value the bar should display
+    /// </summary>
+    public int Value { get; set; } = 0;
+
+    /// <summary>
+    /// Define if the bar should support overflow. Overflow will handle a value range progress from 100% to 200%.
+    /// </summary>
+    public bool UseOverflow { get; set; }
+
+    /// <summary>
+    /// Define if the bar should be displayed with borders.
+    /// </summary>
+    public bool UseBorder {
+        get => TagsList.Contains("bordered");
+        set
+        {
+            if (value) {
+                TagsList.Add("bordered");
+            } else {
+                TagsList.Remove("bordered");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Direction in which the bars will fill.
+    /// </summary>
+    public FillDirection Direction { get; set; } = FillDirection.LeftToRight;
+
+    public ProgressBarNode(string id)
+    {
+        Id         = id;
+        ClassList  = ["progressbar"];
+        ChildNodes = [BarNode, OverflowNode];
+        Stylesheet = BarStylesheet;
+
+        BeforeDraw += UpdateBar;
+    }
+
+    private void UpdateBar(Node _)
+    {
+        if (!IsVisible) return;
+
+        if (Minimum >= Maximum) {
+            // Warn that values used are wrong
+            Logger.Warning($"Bar {Id} with incorrect value: Tried to use {Minimum} which is greater than {Maximum}.");
+            Style.IsVisible = false;
+        }
+
+        float progress = (Value - Minimum) / (float)(Maximum - Minimum);
+        float overflow = 0;
+
+        if (UseOverflow && progress > 1) {
+            overflow = progress - 1;
+            progress = 1;
+        }
+
+        progress = Math.Clamp(progress, 0, 1);
+        overflow = Math.Clamp(overflow, 0, 1);
+
+        int padding     = UseBorder ? PaddingSize * 2 : 0;
+        int innerHeight = Height - padding;
+
+        var progressWidth = (int)(progress * (Width - padding));
+        var overflowWidth = (int)(overflow * (Width - padding));
+
+        BarNode.Style.Size      = new(progressWidth, innerHeight);
+        OverflowNode.Style.Size = new(overflowWidth, innerHeight);
+
+        if (Value >= Maximum) {
+            BarNode.TagsList.Add("full");
+        } else {
+            BarNode.TagsList.Remove("full");
+        }
+
+        if (Direction == FillDirection.RightToLeft) {
+            BarNode.Style.Anchor      = Anchor.TopRight;
+            OverflowNode.Style.Anchor = Anchor.BottomRight;
+        } else {
+            BarNode.Style.Anchor      = Anchor.TopLeft;
+            OverflowNode.Style.Anchor = Anchor.BottomLeft;
+        }
+    }
+
+    /// <summary>
+    /// Default style for progress bars.
+    /// </summary>
+    private static readonly Stylesheet BarStylesheet = new([
+        new(".progressbar", new() {
+            BorderRadius  = 5,
+            IsAntialiased = true,
+        }),
+        new(
+            ".progressbar:bordered",
+            new() {
+                Padding         = new(PaddingSize),
+                BackgroundColor = new("Widget.Background"),
+                StrokeColor     = new("Widget.Border"),
+                StrokeWidth     = 1,
+                StrokeInset     = 1,
+                StrokeRadius    = 4,
+            }
+        ),
+        new(
+            ".bar",
+            new() {
+                Size          = new(0),
+                BorderRadius  = 3,
+                IsAntialiased = true,
+            }
+        ),
+        new(
+            ".bar--current-value",
+            new() {
+                BackgroundColor = new("Window.TextMuted"),
+            }
+        ),
+        new(
+            ".bar--overflow-value",
+            new() {
+                BackgroundColor = new("Window.Text"),
+            }
+        ),
+    ]);
+
+    public enum FillDirection
+    {
+        LeftToRight,
+        RightToLeft,
+    }
+}

--- a/Umbra/src/Windows/Components/ProgressBarNode.cs
+++ b/Umbra/src/Windows/Components/ProgressBarNode.cs
@@ -74,8 +74,9 @@ public class ProgressBarNode : Node
 
         if (Minimum >= Maximum) {
             // Warn that values used are wrong
-            Logger.Warning($"Bar {Id} with incorrect value: Tried to use {Minimum} which is greater than {Maximum}.");
+            Logger.Warning($"Bar {Id} with incorrect value: Minimum {Minimum} >= Maximum {Maximum}.");
             Style.IsVisible = false;
+            return;
         }
 
         float progress = (Value - Minimum) / (float)(Maximum - Minimum);


### PR DESCRIPTION
As people seems to like progress bars a lot, I've created a progress bar component.

- Computes the inner bar width automatically based on minimal, current and maximum value
- Support "Overflow" values (100% to 200% range — useful for gear durability for example)
- Fill direction to control in which direction the value bar will expend
- Border or No Border display mode

Also, this PR adds the progress bar to the durability widget.
