### PR TITLE
MacroIconProvider: Add support for GeneralAction and PvPQuickChat

### DIFF
--- a/Umbra.Game/src/Macro/MacroIconProvider.cs
+++ b/Umbra.Game/src/Macro/MacroIconProvider.cs
@@ -120,17 +120,17 @@ internal sealed unsafe class MacroIconProvider : IMacroIconProvider
 
     private uint GetIconIdForMarker(uint rowId, uint fallbackId)
     {
-        return ((uint?)DataManager.GetExcelSheet<Marker>()!.GetRow(rowId)?.Icon) ?? fallbackId;
+        return (uint?)DataManager.GetExcelSheet<Marker>()!.GetRow(rowId)?.Icon ?? fallbackId;
     }
 
     private uint GetIconIdForBuddyAction(uint rowId, uint fallbackId)
     {
-        return ((uint?)DataManager.GetExcelSheet<BuddyAction>()!.GetRow(rowId)?.Icon) ?? fallbackId;
+        return (uint?)DataManager.GetExcelSheet<BuddyAction>()!.GetRow(rowId)?.Icon ?? fallbackId;
     }
 
     private uint GetIconIdForCompanion(uint rowId, uint fallbackId)
     {
-        return ((uint?)DataManager.GetExcelSheet<Companion>()!.GetRow(rowId)?.Icon) ?? fallbackId;
+        return DataManager.GetExcelSheet<Companion>()!.GetRow(rowId)?.Icon ?? fallbackId;
     }
 
     private uint GetIconIdForGeneralAction(uint rowId, uint fallbackId)
@@ -140,7 +140,7 @@ internal sealed unsafe class MacroIconProvider : IMacroIconProvider
 
     private uint GetIconIdForPetAction(uint rowId, uint fallbackId)
     {
-        return ((uint?)DataManager.GetExcelSheet<PetAction>()!.GetRow(rowId)?.Icon) ?? fallbackId;
+        return (uint?)DataManager.GetExcelSheet<PetAction>()!.GetRow(rowId)?.Icon ?? fallbackId;
     }
 
     private uint GetIconIdForPvPQuickChat(uint rowId, uint fallbackId)
@@ -150,11 +150,11 @@ internal sealed unsafe class MacroIconProvider : IMacroIconProvider
 
     private uint GetIconIdForMount(uint rowId, uint fallbackId)
     {
-        return ((uint?)DataManager.GetExcelSheet<Mount>()!.GetRow(rowId)?.Icon) ?? fallbackId;
+        return DataManager.GetExcelSheet<Mount>()!.GetRow(rowId)?.Icon ?? fallbackId;
     }
 
     private uint GetIconIdForFieldMarker(uint rowId, uint fallbackId)
     {
-        return ((uint?)DataManager.GetExcelSheet<FieldMarker>()!.GetRow(rowId)?.MapIcon) ?? fallbackId;
+        return DataManager.GetExcelSheet<FieldMarker>()!.GetRow(rowId)?.MapIcon ?? fallbackId;
     }
 }

--- a/Umbra.Game/src/Macro/MacroIconProvider.cs
+++ b/Umbra.Game/src/Macro/MacroIconProvider.cs
@@ -86,7 +86,9 @@ internal sealed unsafe class MacroIconProvider : IMacroIconProvider
             RaptureHotbarModule.HotbarSlotType.BuddyAction        => GetIconIdForBuddyAction(rowId, originalId),
             RaptureHotbarModule.HotbarSlotType.Companion          => GetIconIdForCompanion(rowId, originalId),
             RaptureHotbarModule.HotbarSlotType.GearSet            => GetIconIdForGearset((int)rowId + 1),
+            RaptureHotbarModule.HotbarSlotType.GeneralAction      => GetIconIdForGeneralAction(rowId, originalId),
             RaptureHotbarModule.HotbarSlotType.PetAction          => GetIconIdForPetAction(rowId, originalId),
+            RaptureHotbarModule.HotbarSlotType.PvPQuickChat       => GetIconIdForPvPQuickChat(rowId, originalId),
             RaptureHotbarModule.HotbarSlotType.Mount              => GetIconIdForMount(rowId, originalId),
             RaptureHotbarModule.HotbarSlotType.FieldMarker        => GetIconIdForFieldMarker(rowId, originalId),
             _                                                     => originalId,
@@ -131,9 +133,19 @@ internal sealed unsafe class MacroIconProvider : IMacroIconProvider
         return ((uint?)DataManager.GetExcelSheet<Companion>()!.GetRow(rowId)?.Icon) ?? fallbackId;
     }
 
+    private uint GetIconIdForGeneralAction(uint rowId, uint fallbackId)
+    {
+        return (uint?)DataManager.GetExcelSheet<GeneralAction>()!.GetRow(rowId)?.Icon ?? fallbackId;
+    }
+
     private uint GetIconIdForPetAction(uint rowId, uint fallbackId)
     {
         return ((uint?)DataManager.GetExcelSheet<PetAction>()!.GetRow(rowId)?.Icon) ?? fallbackId;
+    }
+
+    private uint GetIconIdForPvPQuickChat(uint rowId, uint fallbackId)
+    {
+        return (uint?)DataManager.GetExcelSheet<QuickChat>()!.GetRow(rowId)?.Icon ?? fallbackId;
     }
 
     private uint GetIconIdForMount(uint rowId, uint fallbackId)


### PR DESCRIPTION
This PR adds support for the following /micon categories:
- `general`, using the GeneralAction sheet, and
- `quickchat`, using the PvPQuickChat sheet.