### PR TITLE
re-add a few icons to the icon picker

### DIFF
--- a/Umbra/src/Windows/Library/IconPicker/IconPickerWindow.cs
+++ b/Umbra/src/Windows/Library/IconPicker/IconPickerWindow.cs
@@ -56,7 +56,12 @@ public sealed partial class IconPickerWindow(uint iconId) : Window
         }, {
             "Shapes", [
                 (0, 0),
-                (82091, 82093), (90001, 90004), (90200, 90263), (90401, 90463), (61901, 61918)
+                (82091, 82093), (90001, 90004), (90200, 90263), (90401, 90463), (61901, 61918),
+                (230131, 230143), // group pose birthday
+                (230201, 230215), // group pose decoration small
+                (230301, 230317), // group pose decoration large
+                (230401, 230433), // group pose stamp symbol
+                (230701, 230715), // group pose stamp nation
             ]
         }, {
             "Minions", [


### PR DESCRIPTION
There are still some icons that are not in the icon picker right now. This just re-adds a few I and some other people missed already.
I'm not quite sure if all of them are in the correct category, but I could at least verify the stamp symbols.