### PR TITLE
Display Vista name in plain text

### DIFF
--- a/Umbra/src/Markers/Library/VistaMarkerFactory.cs
+++ b/Umbra/src/Markers/Library/VistaMarkerFactory.cs
@@ -101,7 +101,7 @@ public class VistaMarkerFactory : WorldMarkerFactory, IDisposable
                 var emote = vista.Emote.Value;
 
                 if (emote.TextCommand.ValueNullable != null) {
-                    subLabel += $" {emote.TextCommand.Value.Command.ToString()}";
+                    subLabel += $" {emote.TextCommand.Value.Command.ExtractText()}";
                 }
             }
 
@@ -112,7 +112,7 @@ public class VistaMarkerFactory : WorldMarkerFactory, IDisposable
                     Key           = id,
                     Position      = new(level.Value.X, level.Value.Y, level.Value.Z),
                     IconId        = 66413,
-                    Label         = $"{vista.Name.ToString()}",
+                    Label         = $"{vista.Name.ExtractText()}",
                     SubLabel      = string.IsNullOrEmpty(subLabel) ? null : subLabel,
                     MapId         = mapId,
                     FadeDistance  = new(fadeDistance, fadeDistance + fadeAttenuation),


### PR DESCRIPTION
The `ReadOnlySeString.ToString()` function generates a payload-representable macro string.
Ship names are written in italics, so it would show "The *Astalicia*" as "The <italic(1)>Astalicia<italic(0)>".
Using `ReadOnlySeString.ExtractText()` instead, only the text portions of a SeString are returned, with a few payloads being converted to text (see https://github.com/NotAdam/Lumina/blob/master/src/Lumina/Text/ReadOnly/ReadOnlySeStringSpan.cs#L256-L274).
If these are unwanted, you will need to manually remove them (i.e. with `input.Replace("\u00AD", string.Empty)`). 🤷‍♂️