### PR TITLE
Make ReadOnlySeString.ReplaceText replace all occurrences

### DIFF
--- a/Umbra.Common/Umbra.Common.csproj
+++ b/Umbra.Common/Umbra.Common.csproj
@@ -42,5 +42,9 @@
 			<HintPath>$(DalamudLibPath)Newtonsoft.Json.dll</HintPath>
 			<Private>false</Private>
 		</Reference>
+		<Reference Include="Microsoft.Extensions.ObjectPool">
+			<HintPath>$(DalamudLibPath)Microsoft.Extensions.ObjectPool.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
     </ItemGroup>
 </Project>

--- a/Umbra.Game/src/Localization/SeTextDecoder.cs
+++ b/Umbra.Game/src/Localization/SeTextDecoder.cs
@@ -61,6 +61,10 @@ Attributive sheet:
     Unknown40 = ?
 */
 
+/// <summary>
+/// Courtesy of Haselnussbomber.<br/>
+/// <see href="https://github.com/Haselnussbomber/HaselCommon/blob/main/HaselCommon/Services/TextDecoder.cs"/>
+/// </summary>
 [Service]
 public class TextDecoder(IClientState clientState, IDataManager dataManager)
 {
@@ -405,13 +409,5 @@ public class TextDecoder(IClientState clientState, IDataManager dataManager)
         ross = builder.ToReadOnlySeString();
         SeStringBuilder.SharedPool.Return(builder);
         return ross;
-    }
-}
-
-public static class ReadOnlySeStringExtensions
-{
-    public static bool Contains(this ReadOnlySeString ross, ReadOnlySpan<byte> needle)
-    {
-        return ross.Data.Span.IndexOf(needle) != -1;
     }
 }


### PR DESCRIPTION
I noticed in my plugin that some german names can contain more than one of the same placeholder (like Glasses#181: `elegant[a] rahmenlos[a] Brille` -> `elegante rahmenlose Brille`), so I changed the `ReadOnlySeString.ReplaceText` extension to replace all occurrences in a string.
Also made it use the shared SeStringBuilder pool, because why not.
And finally, I restored the credits that went missing last update. ^_^'