### PR TITLE
Show correct Assembly version

### DIFF
--- a/Umbra/src/Windows/Library/Settings/SettingsWindow.cs
+++ b/Umbra/src/Windows/Library/Settings/SettingsWindow.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Utility;
+using Dalamud.Utility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,7 +27,10 @@ public class SettingsWindow : Window
 
     protected override void OnOpen()
     {
-        RootNode.QuerySelector("#version")!.NodeValue = $"Umbra v{Framework.DalamudPlugin.Manifest.AssemblyVersion.ToString(3)}";
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        RootNode.QuerySelector("#version")!.NodeValue = version != null
+            ? $"Umbra v{version.ToString(3)}"
+            : "Umbra";
 
         BindFooterButtonActions();
 


### PR DESCRIPTION
When Umbra is in testing, the version is displayed incorrectly because it uses `AssemblyVersion` from the manifest instead of checking `IDalamudPluginInterface.IsTesting` and using `TestingAssemblyVersion`.

But there is a different solution to this, by using the version from the executing assembly directly.
I've never seen it being null, but added a check nonetheless.