### PR TITLE
Hide looted Treasure Coffer Markers

### DIFF
--- a/Umbra/src/Markers/Library/TreasureCofferMarkerFactory.cs
+++ b/Umbra/src/Markers/Library/TreasureCofferMarkerFactory.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using Umbra.Common;
 using Umbra.Game;
 
+using TreasureObject = FFXIVClientStructs.FFXIV.Client.Game.Object.Treasure;
+
 namespace Umbra.Markers.Library;
 
 [Service]
@@ -40,6 +42,10 @@ internal class TreasureCofferMarkerFactory(IObjectTable objectTable, IZoneManage
 
         foreach (IGameObject obj in objectTable) {
             if (!obj.IsValid() || obj.ObjectKind != ObjectKind.Treasure || !obj.IsTargetable) continue;
+            unsafe {
+                var treasureObject = (TreasureObject*)obj.Address;
+                if (treasureObject->Flags.HasFlag(TreasureObject.TreasureFlags.FadedOut)) continue;
+            }
 
             string key = $"TC_{zone.Id}_{(int)obj.Position.X}_{(int)obj.Position.Z}_{obj.DataId}";
             usedIds.Add(key);


### PR DESCRIPTION
When you loot a Treasure Chest and walk away, the marker is still visible until the GameObject despawns.
This change makes it so the marker is removed as soon as the treasure is fading out after being looted, while still being shown when loot is pending.

See https://github.com/aers/FFXIVClientStructs/blob/main/FFXIVClientStructs/FFXIV/Client/Game/Object/Treasure.cs