### PR TITLE
Volume Widget: Replace volume icon with selected channel for right click

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/Volume/VolumeWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Volume/VolumeWidget.cs
@@ -8,9 +8,9 @@ using Umbra.Common;
 namespace Umbra.Widgets;
 
 [ToolbarWidget(
-    "Volume", 
-    "Widget.Volume.Name", 
-    "Widget.Volume.Description", 
+    "Volume",
+    "Widget.Volume.Name",
+    "Widget.Volume.Description",
     ["volume", "audio", "channels", "sound", "sfx", "bgm"]
 )]
 internal sealed partial class VolumeWidget(
@@ -36,7 +36,7 @@ internal sealed partial class VolumeWidget(
 
     protected override void OnDraw()
     {
-        SetFontAwesomeIcon(GetVolumeIcon("SoundMaster", "IsSndMaster"));
+        SetFontAwesomeIcon(GetVolumeIcon());
 
         Popup.ShowOptions = GetConfigValue<bool>("ShowOptions");
         Popup.ShowBgm     = GetConfigValue<bool>("ShowBgm");
@@ -54,8 +54,27 @@ internal sealed partial class VolumeWidget(
 
     private void ToggleMute()
     {
-        string channelName = GetConfigValue<string>("RightClickBehavior") switch 
-        {
+        string channelName = getMuteConfigName();
+
+        _gameConfig.System.Set(channelName, !_gameConfig.System.GetBool(channelName));
+    }
+
+    private FontAwesomeIcon GetVolumeIcon()
+    {
+        if (_gameConfig.System.GetBool(getMuteConfigName())) {
+            return GetConfigValue<FontAwesomeIcon>("MuteIcon");
+        }
+
+        return _gameConfig.System.GetUInt(getVolumeConfigName()) switch {
+            0    => GetConfigValue<FontAwesomeIcon>("OffIcon"),
+            < 50 => GetConfigValue<FontAwesomeIcon>("DownIcon"),
+            _    => GetConfigValue<FontAwesomeIcon>("UpIcon")
+        };
+    }
+
+    private string getMuteConfigName()
+    {
+        return GetConfigValue<string>("RightClickBehavior") switch {
             "Master" => "IsSndMaster",
             "BGM"    => "IsSndBgm",
             "SFX"    => "IsSndSe",
@@ -65,20 +84,19 @@ internal sealed partial class VolumeWidget(
             "PERF"   => "IsSndPerform",
             _        => throw new InvalidOperationException("Invalid volume channel selected.")
         };
-        
-        _gameConfig.System.Set(channelName, !_gameConfig.System.GetBool(channelName));
     }
 
-    private FontAwesomeIcon GetVolumeIcon(string volumeConfigName, string muteConfigName)
+    private string getVolumeConfigName()
     {
-        if (_gameConfig.System.GetBool(muteConfigName)) {
-            return GetConfigValue<FontAwesomeIcon>("MuteIcon");
-        }
-
-        return _gameConfig.System.GetUInt(volumeConfigName) switch {
-            0    => GetConfigValue<FontAwesomeIcon>("OffIcon"),
-            < 50 => GetConfigValue<FontAwesomeIcon>("DownIcon"),
-            _    => GetConfigValue<FontAwesomeIcon>("UpIcon")
+        return GetConfigValue<string>("RightClickBehavior") switch {
+            "Master" => "SoundMaster",
+            "BGM"    => "SoundBgm",
+            "SFX"    => "SoundSe",
+            "VOC"    => "SoundVoice",
+            "AMB"    => "SoundEnv",
+            "SYS"    => "SoundSystem",
+            "PERF"   => "SoundPerform",
+            _        => throw new InvalidOperationException("Invalid volume channel selected.")
         };
     }
 }


### PR DESCRIPTION
This does assume, that it would be helpful in general to show the icon for the selected 'right click' target channel instead of the master volume.
If needed, I could also put this behind a boolean setting.