### PR TITLE
add tooltip to item button when some of the text isn't being displayed

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/ItemButton/ItemButtonWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/ItemButton/ItemButtonWidget.cs
@@ -55,17 +55,21 @@ internal sealed partial class ItemButtonWidget(
         IsVisible = !GetConfigValue<bool>("HideIfNotOwned")
                     || Player.HasItemInInventory(ItemId, 1, GetItemUsage());
 
-        bool showLabel = GetConfigValue<bool>("ShowLabel") && ItemName is not null;
-        bool showCount = GetConfigValue<bool>("ShowCount");
-        int  owned     = Player.GetItemCount(itemId, GetItemUsage());
+        bool showLabel    = GetConfigValue<bool>("ShowLabel") && ItemName is not null;
+        bool showCount    = GetConfigValue<bool>("ShowCount");
+        bool showIconOnly = GetConfigValue<string>("DisplayMode") == DisplayModeIconOnly;
+        int owned         = Player.GetItemCount(itemId, GetItemUsage());
 
-        string name  = showLabel ? ItemName ?? "" : "";
-        string count = showCount ? $"{owned}" : "";
-        string label = showLabel && showCount ? $"{ItemName} x {owned}" : name + count;
+        string name    = showLabel ? ItemName ?? "" : "";
+        string count   = showCount ? $"{owned}" : "";
+        string text    = $"{ItemName} x {owned}";
+        string label   = showLabel && showCount ? text : name + count;
+        string tooltip = showIconOnly || !showLabel || !showCount ? text : "";
 
         SetText(label);
         SetDisabled(!CanUseItem());
         SetGameIconId(IconId ?? 14);
+        SetTooltip(tooltip);
     }
 
     private void UseItem(Node _)

--- a/Umbra/src/Toolbar/Widgets/System/Types/StandardToolbarWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/System/Types/StandardToolbarWidget.cs
@@ -232,6 +232,11 @@ public abstract class StandardToolbarWidget(
         MultiLabelTextBottomNode.Style.OutlineColor = outlineColor;
     }
 
+    protected void SetTooltip(string text)
+    {
+        Node.Tooltip = text;
+    }
+
     protected void SetGameIconId(uint iconId)
     {
         IconNode.Style.IconId         = iconId;


### PR DESCRIPTION
Tooltip will be shown when the DisplayMode is set to ShowIconOnly or when item count or item name is omitted on the button.