### PR TITLE
fix the currencies widgets' custom text colours being overriden

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/Currencies/CurrenciesWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Currencies/CurrenciesWidget.cs
@@ -108,7 +108,6 @@ internal sealed partial class CurrenciesWidget(
             ProgressBarNode.UseOverflow     = true;
             ProgressBarNode.Value           = 200;
         } else {
-            SingleLabelTextNode.Style.Color = null;
             ProgressBarNode.UseOverflow     = false;
 
             if (currency.WeeklyCapacity > 0) {


### PR DESCRIPTION
As of 039c2dc, the custom colours of a currency widget were being overriden sporadically, causing minor flickering alongside the colours not being respected. This simple commit fixes that, and restores old functionality in the process.