### PR TITLE
Do not stretch the toolbar panels if the toolbar itself isn't stretched

### DIFF
--- a/Umbra/Umbra.csproj
+++ b/Umbra/Umbra.csproj
@@ -8,7 +8,7 @@
     <PropertyGroup>
         <Authors>Una</Authors>
         <Company>Una-XIV</Company>
-        <Version>3.1.3</Version>
+        <Version>3.1.4</Version>
         <Description>Umbra UI</Description>
         <Copyright>(C)2025, by Una</Copyright>
         <PackageProjectUrl>https://github.com/una-xiv/umbra</PackageProjectUrl>

--- a/Umbra/src/Toolbar/Toolbar.Nodes.cs
+++ b/Umbra/src/Toolbar/Toolbar.Nodes.cs
@@ -81,21 +81,27 @@ internal partial class Toolbar
         CenterPanel.Style.Gap      = ItemSpacing;
         RightPanel.Style.Gap       = ItemSpacing;
 
-        LeftPanel.ComputeBoundingSize();
-        CenterPanel.ComputeBoundingSize();
-        RightPanel.ComputeBoundingSize();
-
         LeftPanel.Style.Size   = new();
         CenterPanel.Style.Size = new();
         RightPanel.Style.Size  = new();
+        
+        if (_toolbarNode.ClassList.Contains("stretched")) {
+            LeftPanel.ComputeBoundingSize();
+            CenterPanel.ComputeBoundingSize();
+            RightPanel.ComputeBoundingSize();
 
-        float centerX1 = (ToolbarXPosition - (CenterPanel.Bounds.MarginSize.Width / 2f));
-        float centerX2 = (ToolbarXPosition + (CenterPanel.Bounds.MarginSize.Width / 2f));
-
-        LeftPanel.Style.Size.Width  = (int)centerX1 - 1;
-        LeftPanel.Style.AutoSize    = (AutoSize.Fit, AutoSize.Grow);
-        RightPanel.Style.Size.Width = (int)(ImGui.GetMainViewport().WorkSize.X - centerX2) - 1;
-        RightPanel.Style.AutoSize   = (AutoSize.Fit, AutoSize.Grow);
+            float centerX1 = (ToolbarXPosition - (CenterPanel.Bounds.MarginSize.Width / 2f));
+            float centerX2 = (ToolbarXPosition + (CenterPanel.Bounds.MarginSize.Width / 2f));
+        
+            LeftPanel.Style.Size.Width  = (int)centerX1 - 1;
+            LeftPanel.Style.AutoSize    = (AutoSize.Fit, AutoSize.Grow);
+            RightPanel.Style.Size.Width = (int)(ImGui.GetMainViewport().WorkSize.X - centerX2) - 1;
+            RightPanel.Style.AutoSize   = (AutoSize.Fit, AutoSize.Grow);
+        } else {
+            LeftPanel.Style.AutoSize    = (AutoSize.Fit, AutoSize.Grow);
+            CenterPanel.Style.AutoSize    = (AutoSize.Fit, AutoSize.Grow);
+            RightPanel.Style.AutoSize    = (AutoSize.Fit, AutoSize.Grow);
+        }
 
         _toolbarNode.Render(
             ImGui.GetBackgroundDrawList(ImGui.GetMainViewport()),


### PR DESCRIPTION
This fixes the ongoing issue in the support channel on Discord