### PR TITLE
Allow to render only the main toolbar or only auxbars

### DIFF
--- a/Umbra/src/Toolbar/Toolbar.cs
+++ b/Umbra/src/Toolbar/Toolbar.cs
@@ -8,13 +8,14 @@ internal sealed partial class Toolbar(AuxBarManager auxBars, IPlayer player, Umb
     [OnDraw(executionOrder: int.MaxValue)]
     private void DrawToolbar()
     {
-        if (!Enabled || !visibility.IsToolbarVisible()) return;
-
         UpdateToolbarWidth();
         UpdateToolbarNodeClassList();
         UpdateToolbarAutoHideOffset();
 
-        RenderToolbarNode();
+        if (Enabled && visibility.IsToolbarVisible()) {
+            RenderToolbarNode();
+        }
+        
         RenderAuxBarNodes();
     }
 


### PR DESCRIPTION
This was talked before on the discord, some people are not using the main toolbar and are just hiding it by setting a negative offset, so let's give them a real option