### PR TITLE
fix: Apply unique IDs to auxiliary bars

### DIFF
--- a/Umbra/src/Toolbar/AuxBar/AuxBarManager.cs
+++ b/Umbra/src/Toolbar/AuxBar/AuxBarManager.cs
@@ -119,10 +119,10 @@ internal sealed class AuxBarManager : IDisposable
            .Where(node => node.Item1.WidgetCount > 0)
            .ToList();
 
-    public AuxBarConfig CreateBar()
+    public AuxBarConfig CreateBar(string id)
     {
         var config = new AuxBarConfig {
-            Id   = $"aux{AuxBarConfigs.Count}",
+            Id   = id,
             Name = $"Aux Bar #{AuxBarConfigs.Count + 1}",
         };
 
@@ -131,6 +131,11 @@ internal sealed class AuxBarManager : IDisposable
         Persist();
 
         return config;
+    }
+    
+    public AuxBarConfig CreateBar()
+    {
+        return CreateBar($"aux{Guid.NewGuid():N}");
     }
 
     public void DeleteBar(string id, bool confirm = true, bool persist = true)

--- a/Umbra/src/Toolbar/Widgets/System/WidgetManager.cs
+++ b/Umbra/src/Toolbar/Widgets/System/WidgetManager.cs
@@ -159,7 +159,7 @@ internal sealed partial class WidgetManager : IDisposable
                 }
                 
                 // Create the aux bar if it doesn't exist yet.
-                var aux = Framework.Service<AuxBarManager>().CreateBar();
+                var aux = Framework.Service<AuxBarManager>().CreateBar(location);
                 panel = Toolbar.GetPanel(aux.Id);
 
                 if (panel == null) {


### PR DESCRIPTION
This fixes the random spam of auxiliary bars when importing a profile.