### PR TITLE
Various UI fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "drawing"]
 	path = drawing
-	url = https://github.com/una-xiv/drawing.git
+	url = git@github.com:alexpado/umbra-drawing.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "drawing"]
 	path = drawing
-	url = git@github.com:alexpado/umbra-drawing.git
+	url = https://github.com/una-xiv/drawing.git

--- a/Umbra/i18n/de.json
+++ b/Umbra/i18n/de.json
@@ -1514,6 +1514,8 @@
   "Color.Misc.CompleteSpiritbondBar.Description": "Farbe, die für den Bindungsleiste bei 100 % verwendet wird.",
   "Color.Misc.MaxLevelIndicator.Name": "Maximallevelindikator",
   "Color.Misc.MaxLevelIndicator.Description": "Farbe, die als Indikator für das Maximallevel eines Jobs verwendet wird.",
+  "Color.Misc.TooltipBackground.Name": "Tooltip-Hintergrund",
+  "Color.Misc.TooltipBackground.Description": "Farbe, die als Hintergrund für Tooltips beim Überfahren von Elementen verwendet wird.",
   "ToolbarProfilesWindow.Title": "Symbolleistenprofile",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "Berufsbasierte Profile verwenden",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "Profile basierend auf deinem aktuellen Beruf automatisch wechseln. Wenn diese Option aktiviert ist, wird der aktive Profilauswähler überschrieben und stattdessen berufsspezifische Profile verwendet.",

--- a/Umbra/i18n/de.json
+++ b/Umbra/i18n/de.json
@@ -1516,6 +1516,8 @@
   "Color.Misc.MaxLevelIndicator.Description": "Farbe, die als Indikator für das Maximallevel eines Jobs verwendet wird.",
   "Color.Misc.TooltipBackground.Name": "Tooltip-Hintergrund",
   "Color.Misc.TooltipBackground.Description": "Farbe, die als Hintergrund für Tooltips beim Überfahren von Elementen verwendet wird.",
+  "Color.Misc.TooltipText.Name": "Textfarbe für Tooltips",
+  "Color.Misc.TooltipText.Description": "Farbe, die als Textfarbe für Tooltips beim Überfahren von Elementen verwendet wird.",
   "ToolbarProfilesWindow.Title": "Symbolleistenprofile",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "Berufsbasierte Profile verwenden",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "Profile basierend auf deinem aktuellen Beruf automatisch wechseln. Wenn diese Option aktiviert ist, wird der aktive Profilauswähler überschrieben und stattdessen berufsspezifische Profile verwendet.",

--- a/Umbra/i18n/en.json
+++ b/Umbra/i18n/en.json
@@ -1516,6 +1516,8 @@
   "Color.Misc.MaxLevelIndicator.Description": "Color used to indicate the maximum job level.",
   "Color.Misc.TooltipBackground.Name": "Tooltip Background",
   "Color.Misc.TooltipBackground.Description": "Color used as background for tooltips when hovering elements.",
+  "Color.Misc.TooltipText.Name": "Tooltip Text Color",
+  "Color.Misc.TooltipText.Description": "Color used as text color for tooltips when hovering elements.",
   "ToolbarProfilesWindow.Title": "Toolbar Profiles",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "Use job-based profiles",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "Automatically switch profiles based on your current job. Enabling this option will override the active profile selector and instead use job-specific profiles.",

--- a/Umbra/i18n/en.json
+++ b/Umbra/i18n/en.json
@@ -1514,6 +1514,8 @@
   "Color.Misc.CompleteSpiritbondBar.Description": "Color used for the spiritbond bar when reaching 100%.",
   "Color.Misc.MaxLevelIndicator.Name": "Maximum Level indicator",
   "Color.Misc.MaxLevelIndicator.Description": "Color used to indicate the maximum job level.",
+  "Color.Misc.TooltipBackground.Name": "Tooltip Background",
+  "Color.Misc.TooltipBackground.Description": "Color used as background for tooltips when hovering elements.",
   "ToolbarProfilesWindow.Title": "Toolbar Profiles",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "Use job-based profiles",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "Automatically switch profiles based on your current job. Enabling this option will override the active profile selector and instead use job-specific profiles.",

--- a/Umbra/i18n/fr.json
+++ b/Umbra/i18n/fr.json
@@ -1273,6 +1273,8 @@
   "Color.Misc.CompleteSpiritbondBar.Description": "Couleur utilisée pour la barre de taux de symbiose lorsqu'elle atteint 100%.",
   "Color.Misc.MaxLevelIndicator.Name": "Indicateur de niveau maximum",
   "Color.Misc.MaxLevelIndicator.Description": "Couleur utilisée pour indiquer le niveau de poste maximum.",
+  "Color.Misc.TooltipBackground.Name": "Arrière-plan de l’infobulle",
+  "Color.Misc.TooltipBackground.Description": "Couleur utilisée comme arrière-plan pour les info-bulles lors du survol des éléments.",
   "ToolbarProfilesWindow.Title": "Profils de barre d'outils",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "Utiliser des profils basés sur le travail",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "Changer automatiquement de profil en fonction de votre travail actuel. Activer cette option remplacera le sélecteur de profil actif et utilisera à la place des profils spécifiques au travail.",

--- a/Umbra/i18n/fr.json
+++ b/Umbra/i18n/fr.json
@@ -1275,6 +1275,8 @@
   "Color.Misc.MaxLevelIndicator.Description": "Couleur utilisée pour indiquer le niveau de poste maximum.",
   "Color.Misc.TooltipBackground.Name": "Arrière-plan de l’infobulle",
   "Color.Misc.TooltipBackground.Description": "Couleur utilisée comme arrière-plan pour les info-bulles lors du survol des éléments.",
+  "Color.Misc.TooltipText.Name": "Couleur du texte de l'infobulle",
+  "Color.Misc.TooltipText.Description": "Couleur utilisée comme couleur de texte pour les infobulles lors du survol des éléments.",
   "ToolbarProfilesWindow.Title": "Profils de barre d'outils",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "Utiliser des profils basés sur le travail",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "Changer automatiquement de profil en fonction de votre travail actuel. Activer cette option remplacera le sélecteur de profil actif et utilisera à la place des profils spécifiques au travail.",

--- a/Umbra/i18n/ja.json
+++ b/Umbra/i18n/ja.json
@@ -1514,6 +1514,8 @@
   "Color.Misc.CompleteSpiritbondBar.Description": "スピリットボンドバーが100％に達したときに使用される色。",
   "Color.Misc.MaxLevelIndicator.Name": "最大レベルインジケーター",
   "Color.Misc.MaxLevelIndicator.Description": "最大ジョブレベルを示すために使用される色。",
+  "Color.Misc.TooltipBackground.Name": "ツールチップの背景",
+  "Color.Misc.TooltipBackground.Description": "要素にカーソルを合わせたときに表示されるツールチップの背景として使用される色。",
   "ToolbarProfilesWindow.Title": "ツールバープロファイル",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "ジョブベースのプロファイルを使用する",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "現在のジョブに基づいてプロファイルを自動的に切り替えます。このオプションを有効にすると、アクティブなプロファイルセレクタが上書きされ、代わりにジョブ固有のプロファイルが使用されます。",

--- a/Umbra/i18n/ja.json
+++ b/Umbra/i18n/ja.json
@@ -1516,6 +1516,8 @@
   "Color.Misc.MaxLevelIndicator.Description": "最大ジョブレベルを示すために使用される色。",
   "Color.Misc.TooltipBackground.Name": "ツールチップの背景",
   "Color.Misc.TooltipBackground.Description": "要素にカーソルを合わせたときに表示されるツールチップの背景として使用される色。",
+  "Color.Misc.TooltipText.Name": "ツールチップのテキストカラー",
+  "Color.Misc.TooltipText.Description": "要素にカーソルを合わせたときにツールチップのテキスト色として使用される色です。",
   "ToolbarProfilesWindow.Title": "ツールバープロファイル",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "ジョブベースのプロファイルを使用する",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "現在のジョブに基づいてプロファイルを自動的に切り替えます。このオプションを有効にすると、アクティブなプロファイルセレクタが上書きされ、代わりにジョブ固有のプロファイルが使用されます。",

--- a/Umbra/i18n/zh.json
+++ b/Umbra/i18n/zh.json
@@ -1516,6 +1516,8 @@
   "Color.Misc.MaxLevelIndicator.Description": "用于指示最大工作等级的颜色。",
   "Color.Misc.TooltipBackground.Name": "工具提示背景",
   "Color.Misc.TooltipBackground.Description": "当鼠标悬停在元素上时用作工具提示背景的颜色。",
+  "Color.Misc.TooltipText.Name": "工具提示文本颜色",
+  "Color.Misc.TooltipText.Description": "当鼠标悬停在元素上时，用作工具提示文本颜色的颜色。",
   "ToolbarProfilesWindow.Title": "工具栏配置",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "使用基于工作岗位的配置",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "根据您当前的工作岗位自动切换配置。启用此选项将覆盖活动配置选择器，并使用特定工作岗位的配置。",

--- a/Umbra/i18n/zh.json
+++ b/Umbra/i18n/zh.json
@@ -1514,6 +1514,8 @@
   "Color.Misc.CompleteSpiritbondBar.Description": "达到100%时精炼度的颜色。",
   "Color.Misc.MaxLevelIndicator.Name": "最大等级指示器",
   "Color.Misc.MaxLevelIndicator.Description": "用于指示最大工作等级的颜色。",
+  "Color.Misc.TooltipBackground.Name": "工具提示背景",
+  "Color.Misc.TooltipBackground.Description": "当鼠标悬停在元素上时用作工具提示背景的颜色。",
   "ToolbarProfilesWindow.Title": "工具栏配置",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Name": "使用基于工作岗位的配置",
   "ToolbarProfilesWindow.UseJobAssociatedProfiles.Description": "根据您当前的工作岗位自动切换配置。启用此选项将覆盖活动配置选择器，并使用特定工作岗位的配置。",

--- a/Umbra/src/Toolbar/Toolbar.cs
+++ b/Umbra/src/Toolbar/Toolbar.cs
@@ -10,6 +10,9 @@ internal sealed partial class Toolbar(AuxBarManager auxBars, IPlayer player, Umb
     {
         if (!visibility.IsToolbarVisible()) return;
 
+        Node.TooltipBackgroundColor = Color.GetNamedColor("Misc.TooltipBackground");
+        Node.TooltipTextColor       = Color.GetNamedColor("Window.TextMuted");
+
         UpdateToolbarWidth();
         UpdateToolbarNodeClassList();
         UpdateToolbarAutoHideOffset();

--- a/Umbra/src/Toolbar/Toolbar.cs
+++ b/Umbra/src/Toolbar/Toolbar.cs
@@ -11,7 +11,7 @@ internal sealed partial class Toolbar(AuxBarManager auxBars, IPlayer player, Umb
         if (!visibility.IsToolbarVisible()) return;
 
         Node.TooltipBackgroundColor = Color.GetNamedColor("Misc.TooltipBackground");
-        Node.TooltipTextColor       = Color.GetNamedColor("Window.TextMuted");
+        Node.TooltipTextColor       = Color.GetNamedColor("Misc.TooltipText");
 
         UpdateToolbarWidth();
         UpdateToolbarNodeClassList();

--- a/Umbra/src/Toolbar/Widgets/Library/GearsetSwitcher/Popup/GearsetSwitcherPopup.Columns.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/GearsetSwitcher/Popup/GearsetSwitcherPopup.Columns.cs
@@ -41,10 +41,11 @@ internal sealed partial class GearsetSwitcherPopup
         groupNode.Style.IsVisible = enabled;
 
         Node bodyNode = groupNode.QuerySelector(".body")!;
-        
+
         groupNode.QuerySelector(".title")!.Style.IsVisible = showTitle;
         groupNode.QuerySelector(".title")!.Style.Size      = new(0, _buttonHeight + 4);
 
+        bodyNode.ToggleClass("scrollbars", _enableRoleScrolling);
         if (_enableRoleScrolling) {
             int   count = Math.Min(maxChildren, bodyNode.ChildNodes.Count);
             float gap   = bodyNode.ComputedStyle.Gap;
@@ -74,7 +75,7 @@ internal sealed partial class GearsetSwitcherPopup
 
         groupNode.QuerySelector(".title")!.Style.Size = new(0, _buttonHeight);
         groupNode.Style.IsVisible                     = true;
-        
+
         LeftColumnNode.AppendChild(groupNode);
         GearsetGroupNodes.Add(category, groupNode);
     }

--- a/Umbra/src/Toolbar/Widgets/Library/Teleport/TeleportWidgetPopup.Nodes.Condensed.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/Teleport/TeleportWidgetPopup.Nodes.Condensed.cs
@@ -17,7 +17,7 @@ internal partial class TeleportWidgetPopup
         CondensedSidePanelNode.AppendChild(new() { ClassList = ["side-panel-spacer"], SortIndex = int.MinValue });
         
         Node contentsWrapper = new() {
-            ClassList  = ["contents"],
+            ClassList  = ["contents", "scrollbars"],
             ChildNodes = [new() { ClassList = ["list"] }],
         };
 

--- a/Umbra/src/Umbra.Colors.cs
+++ b/Umbra/src/Umbra.Colors.cs
@@ -403,6 +403,7 @@ internal class UmbraColors
         Color.AssignByName("Misc.CompleteSpiritbondBar",          0xFFD0D0D0);
         Color.AssignByName("Misc.MaxLevelIndicator",              0xFF62A5F5);
         Color.AssignByName("Misc.TooltipBackground",              0xFF353535);
+        Color.AssignByName("Misc.TooltipText",                    0xFFCACACA);
     }
 
     private static void OnConfigProfileChanged(string _)

--- a/Umbra/src/Umbra.Colors.cs
+++ b/Umbra/src/Umbra.Colors.cs
@@ -402,6 +402,7 @@ internal class UmbraColors
         Color.AssignByName("Misc.SpiritbondBar",                  0xFFb98e4c);
         Color.AssignByName("Misc.CompleteSpiritbondBar",          0xFFD0D0D0);
         Color.AssignByName("Misc.MaxLevelIndicator",              0xFF62A5F5);
+        Color.AssignByName("Misc.TooltipBackground",              0xFF353535);
     }
 
     private static void OnConfigProfileChanged(string _)

--- a/Umbra/src/Windows/Library/BitmapIconPicker/BitmapIconGridNode.cs
+++ b/Umbra/src/Windows/Library/BitmapIconPicker/BitmapIconGridNode.cs
@@ -43,7 +43,7 @@ public class BitmapIconGridNode : Node
     {
         Selected  = selected;
         NodeValue = " ";
-        ClassList = ["fa-icon-grid"];
+        ClassList = ["fa-icon-grid", "scrollbars"];
 
         FilterIconListInternal();
     }

--- a/Umbra/src/Windows/Library/BitmapIconPicker/BitmapIconGridNode.cs
+++ b/Umbra/src/Windows/Library/BitmapIconPicker/BitmapIconGridNode.cs
@@ -66,6 +66,10 @@ public class BitmapIconGridNode : Node
         ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 0));
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0, 0));
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(8 * ScaleFactor));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarBg, Color.GetNamedColor("Window.ScrollbarTrack"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrab, Color.GetNamedColor("Window.ScrollbarThumb"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabHovered, Color.GetNamedColor("Window.ScrollbarThumbHover"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabActive, Color.GetNamedColor("Window.ScrollbarThumbActive"));
         ImGui.SetCursorScreenPos(pos);
 
         if (ImGui.BeginChild("BitmapIconPickerIconGrid", size.ToVector2(), false, ImGuiWindowFlags.NoMove)) {
@@ -74,6 +78,7 @@ public class BitmapIconGridNode : Node
 
         ImGui.EndChild();
         ImGui.PopStyleVar(3);
+        ImGui.PopStyleColor(4);
     }
 
     private void FilterIconList()

--- a/Umbra/src/Windows/Library/FaIconPicker/FaIconGridNode.cs
+++ b/Umbra/src/Windows/Library/FaIconPicker/FaIconGridNode.cs
@@ -61,6 +61,10 @@ public class FaIconGridNode : Node
         ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 0));
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0, 0));
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(8 * ScaleFactor));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarBg, Color.GetNamedColor("Window.ScrollbarTrack"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrab, Color.GetNamedColor("Window.ScrollbarThumb"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabHovered, Color.GetNamedColor("Window.ScrollbarThumbHover"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabActive, Color.GetNamedColor("Window.ScrollbarThumbActive"));
         ImGui.SetCursorScreenPos(pos);
 
         Framework.DalamudPlugin.UiBuilder.IconFontHandle.Push();
@@ -73,6 +77,7 @@ public class FaIconGridNode : Node
 
         ImGui.EndChild();
         ImGui.PopStyleVar(3);
+        ImGui.PopStyleColor(4);
     }
 
     private void FilterIconList()

--- a/Umbra/src/Windows/Library/FaIconPicker/FaIconGridNode.cs
+++ b/Umbra/src/Windows/Library/FaIconPicker/FaIconGridNode.cs
@@ -38,7 +38,7 @@ public class FaIconGridNode : Node
     {
         Selected  = selected;
         NodeValue = " ";
-        ClassList = ["fa-icon-grid"];
+        ClassList = ["fa-icon-grid", "scrollbars"];
 
         FilterIconListInternal();
     }

--- a/Umbra/src/Windows/Library/GameGlyphPicker/GameGlyphGridNode.cs
+++ b/Umbra/src/Windows/Library/GameGlyphPicker/GameGlyphGridNode.cs
@@ -63,6 +63,10 @@ public class GameGlyphGridNode : Node
         ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 0));
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0, 0));
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(8 * ScaleFactor));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarBg, Color.GetNamedColor("Window.ScrollbarTrack"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrab, Color.GetNamedColor("Window.ScrollbarThumb"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabHovered, Color.GetNamedColor("Window.ScrollbarThumbHover"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabActive, Color.GetNamedColor("Window.ScrollbarThumbActive"));
         ImGui.SetCursorScreenPos(pos);
 
         if (ImGui.BeginChild("SeIconPickerIconGrid", size.ToVector2(), false, ImGuiWindowFlags.NoMove)) {
@@ -71,6 +75,7 @@ public class GameGlyphGridNode : Node
 
         ImGui.EndChild();
         ImGui.PopStyleVar(3);
+        ImGui.PopStyleColor(4);
     }
 
     private void FilterIconList()

--- a/Umbra/src/Windows/Library/GameIconPicker/GameIconGridNode.cs
+++ b/Umbra/src/Windows/Library/GameIconPicker/GameIconGridNode.cs
@@ -38,6 +38,10 @@ public class GameIconGridNode : Node
         ImGui.PushStyleVar(ImGuiStyleVar.FramePadding, new Vector2(0, 0));
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, new Vector2(0, 0));
         ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(8 * ScaleFactor));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarBg, Color.GetNamedColor("Window.ScrollbarTrack"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrab, Color.GetNamedColor("Window.ScrollbarThumb"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabHovered, Color.GetNamedColor("Window.ScrollbarThumbHover"));
+        ImGui.PushStyleColor(ImGuiCol.ScrollbarGrabActive, Color.GetNamedColor("Window.ScrollbarThumbActive"));
         ImGui.SetCursorScreenPos(pos);
 
         if (ImGui.BeginChild("IconPickerIconGrid", size.ToVector2(), false, ImGuiWindowFlags.NoMove)) {
@@ -46,6 +50,7 @@ public class GameIconGridNode : Node
 
         ImGui.EndChild();
         ImGui.PopStyleVar(3);
+        ImGui.PopStyleColor(4);
     }
 
     private void DrawIcon(uint iconId)

--- a/Umbra/udt/umbra/auxbar.xml
+++ b/Umbra/udt/umbra/auxbar.xml
@@ -8,8 +8,6 @@
     
     <![CDATA[
     .toolbar {
-        padding: 0 4;
-        
         & > .section.aux-section {
             gap: 2;
             padding: 0 2;

--- a/Umbra/udt/umbra/globals.xml
+++ b/Umbra/udt/umbra/globals.xml
@@ -1,6 +1,7 @@
 ﻿<udt>
     <![CDATA[
     .scrollbars {
+        scrollbar-track-color: "Window.ScrollbarTrack";
         scrollbar-thumb-color: "Window.ScrollbarThumb";
         scrollbar-thumb-hover-color: "Window.ScrollbarThumbHover";
         scrollbar-thumb-active-color: "Window.ScrollbarThumbActive";

--- a/Umbra/udt/umbra/widgets/_popup.xml
+++ b/Umbra/udt/umbra/widgets/_popup.xml
@@ -3,6 +3,8 @@
         <node class="wrapper"/>
     </node>
     <![CDATA[
+    @import "globals";
+
     .box { padding: 10; }
     
     .popup {

--- a/Umbra/udt/umbra/widgets/_popup_menu.xml
+++ b/Umbra/udt/umbra/widgets/_popup_menu.xml
@@ -2,6 +2,8 @@
     <node class="popup"/>
     
     <![CDATA[
+    @import "globals";
+
     .popup {
         flow: vertical;
         gap: 2;

--- a/Umbra/udt/umbra/widgets/popup_gearset_switcher.xml
+++ b/Umbra/udt/umbra/widgets/popup_gearset_switcher.xml
@@ -48,6 +48,8 @@
     </template>
 
     <![CDATA[
+    @import "globals";
+
     .popup {
         flow: vertical;
 
@@ -210,8 +212,7 @@
             gap: 6;
 
             &.scrolling {
-                padding: 0 12 0 0;
-                scrollbar-track-color: 0;
+                padding: 0 24 0 0;
             }
         }
     }

--- a/Umbra/udt/umbra/widgets/popup_teleport.xml
+++ b/Umbra/udt/umbra/widgets/popup_teleport.xml
@@ -11,6 +11,8 @@
     </node>
     
     <![CDATA[
+    @import "globals";
+
     #condensed-ui {
         is-visible: false;
     }

--- a/Umbra/udt/umbra/widgets/popup_teleport_condensed.xml
+++ b/Umbra/udt/umbra/widgets/popup_teleport_condensed.xml
@@ -93,7 +93,6 @@
             auto-size: grow;
             padding: 0 8;
             margin: 1 8 1 0;
-            scrollbar-track-color: 0;
             
             & > .list {
                 auto-size: grow fit;

--- a/Umbra/udt/umbra/widgets/popup_teleport_extended.xml
+++ b/Umbra/udt/umbra/widgets/popup_teleport_extended.xml
@@ -48,7 +48,6 @@
                 background-color: "Widget.PopupBackground.Gradient2";
                 border-radius: 7;
                 rounded-corners: top-right bottom-right;
-                drop-shadow: 0 0 8 8;
             }
             
             & > .header {

--- a/Umbra/udt/umbra/widgets/popup_unified_main_menu.xml
+++ b/Umbra/udt/umbra/widgets/popup_unified_main_menu.xml
@@ -13,20 +13,22 @@
                 <button-node id="btn-shutdown" icon="PowerOff" is-ghost="true"/>
             </node>
         </node>
-        
+
         <node class="body">
             <node class="side-panel-wrapper">
-                <node class="side-panel" overflow="false">
+                <node class="side-panel scrollbars" overflow="false">
                     <node id="side-panel"/>
                 </node>
             </node>
-            <node class="contents" overflow="false">
+            <node class="contents scrollbars" overflow="false">
                 <node id="contents"/>
             </node>
         </node>
     </node>
     
     <![CDATA[
+    @import "globals";
+
     .popup {
         flow: vertical;
         margin: 2;
@@ -99,7 +101,6 @@
                     border-color: "Widget.Border";
                     border-width: 1 1 1 0;
                     auto-size: grow;
-                    scrollbar-track-color: "Widget.PopupBackground.Gradient2";
                         
                     & > #side-panel {
                         flow: vertical;
@@ -274,5 +275,5 @@
             }
         }
     }
-    ]]>
-</udt>
+    
+]]></udt>

--- a/Umbra/udt/umbra/windows/fa_icon_picker/window.xml
+++ b/Umbra/udt/umbra/windows/fa_icon_picker/window.xml
@@ -6,7 +6,7 @@
                 <string-input-node id="search" immediate="true"/>
             </node>
         </node>
-        <node class="body"/>
+        <node class="body scrollbars"/>
         <node class="footer">
             <node class="buttons">
                 <button-node class="button" id="cancel" label="_L(Cancel)"/>
@@ -16,6 +16,8 @@
     </node>
     
     <![CDATA[
+    @import "globals";
+
     .fa-icon-picker-window {
         flow: vertical;
         auto-size: grow grow;    
@@ -60,10 +62,6 @@
                 gap: 10;    
             }
         }
-    }
-    
-    .fa-icon-grid {
-        scrollbar-track-color: "Window.Background";
     }
     ]]>
 </udt>

--- a/Umbra/udt/umbra/windows/settings/_shared.xml
+++ b/Umbra/udt/umbra/windows/settings/_shared.xml
@@ -11,7 +11,6 @@
             size: 0 0;
             auto-size: fit grow;
             background-color: "Window.Background";
-            scrollbar-track-color: "Window.Background";
             
             & > .side-panel-content {
                 flow: vertical;
@@ -23,7 +22,6 @@
             flow: vertical;
             auto-size: grow;
             margin: 10;
-            scrollbar-track-color: "Window.BackgroundLight";
             background-color: "Window.BackgroundLight";
             drop-shadow: 0 0 5 5;
             
@@ -41,7 +39,6 @@
         .sidebar {
             flow: vertical;
             auto-size: grow;
-            scrollbar-track-color: "Window.Background";
             
             & > #sidebar-buttons {
                 anchor: top-left;

--- a/Umbra/udt/umbra/windows/settings/components/widget_control_column.xml
+++ b/Umbra/udt/umbra/windows/settings/components/widget_control_column.xml
@@ -1,7 +1,7 @@
 ﻿<udt>
     <node class="column">
         <node class="header" value="${label}"/>
-        <node class="widgets"
+        <node class="widgets scrollbars"
               overflow="false"
               sortable="true"
               sortable-group-id="widgets-column"
@@ -41,7 +41,6 @@
         & > .widgets {
             flow: vertical;
             auto-size: grow;
-            scrollbar-track-color: 0;
             padding: 8;
             gap: 8;
             stroke-width: 1;

--- a/Umbra/udt/umbra/windows/settings/modules/plugins_module.xml
+++ b/Umbra/udt/umbra/windows/settings/modules/plugins_module.xml
@@ -14,7 +14,7 @@
         <node id="plugins">
             <node class="left-side">
                 <node class="section-title" value="_L(Settings.PluginsModule.InstalledPlugins)"/>
-                <node class="plugin-list" overflow="false">
+                <node class="plugin-list scrollbars" overflow="false">
                     <node id="plugin-list"/>
                 </node>
             </node>
@@ -97,7 +97,6 @@
                 & > .plugin-list {
                     flow: vertical;
                     auto-size: grow;
-                    scrollbar-track-color: 0;
                     
                     & > #plugin-list {
                         flow: vertical;

--- a/Umbra/udt/umbra/windows/settings/modules/toolbar_widgets_module.xml
+++ b/Umbra/udt/umbra/windows/settings/modules/toolbar_widgets_module.xml
@@ -3,7 +3,7 @@
     
     <node id="main">
         <node class="list-panel">
-            <node class="list" overflow="false">
+            <node class="list scrollbars" overflow="false">
                 <node id="bar-list"/>
             </node>
             <node class="footer">
@@ -21,7 +21,7 @@
     </node>
     
     <template name="aux-config">
-        <node class="config" overflow="false">
+        <node class="config scrollbars" overflow="false">
             <node class="list">
                 <string-input-node class="input-name" label="_L(Settings.WidgetsModule.Aux.Name.Name)"/>
                 <separator label="_L(Settings.WidgetsModule.Aux.Positioning)"/>
@@ -80,7 +80,6 @@
                 flow: vertical;
                 auto-size: grow;
                 gap: 8;
-                scrollbar-track-color: 0;
                 
                 & > #bar-list {
                     flow: vertical;
@@ -166,7 +165,6 @@
                     auto-size: grow;
                     flow: vertical;
                     background-color: "Window.Background";
-                    scrollbar-track-color: 0;
                     stroke-color: "Input.Background";
                     stroke-width: 1;
                     border-radius: 5;

--- a/Umbra/udt/umbra/windows/shortcut_picker/window.xml
+++ b/Umbra/udt/umbra/windows/shortcut_picker/window.xml
@@ -6,10 +6,12 @@
                 <string-input-node id="Search" max-length="128" immediate="true"/>
             </node>
         </node>
-        <node id="ItemList" overflow="false"/>
+        <node id="ItemList" class="scrollbars" overflow="false"/>
     </node>
 
     <![CDATA[
+    @import "globals";
+
     #main {
         auto-size: grow;
         flow: vertical;

--- a/Umbra/udt/umbra/windows/variables_editor/window.xml
+++ b/Umbra/udt/umbra/windows/variables_editor/window.xml
@@ -3,7 +3,7 @@
     
     <node id="main">
         <tab-bar/>
-        <node class="body" overflow="false">
+        <node class="body scrollbars" overflow="false">
             <node id="variables"/>
         </node>
         <node class="footer ui-window-footer">
@@ -36,7 +36,6 @@
         & > .body {
             auto-size: grow;
             background-color: "Window.Background";
-            scrollbar-track-color: "Window.Background";
             
             & > #variables {
                 flow: vertical;

--- a/Umbra/udt/umbra/windows/widget_browser/window.xml
+++ b/Umbra/udt/umbra/windows/widget_browser/window.xml
@@ -6,7 +6,7 @@
                 <string-input-node id="search" immediate="true"/>
             </node>
         </node>
-        <node class="body" overflow="false">
+        <node class="body scrollbars" overflow="false">
             <node class="list" id="widgets"/>
         </node>
         <node class="footer ui-window-footer">
@@ -62,7 +62,6 @@
         & > .body {
             auto-size: grow;
             background-color: "Window.Background";
-            scrollbar-track-color: "Window.Background";
             
             & > .list {
                 flow: vertical;


### PR DESCRIPTION
- Makes all scrollbars respect the user's color theme
- Removed a drop-shadow on the teleport popup that caused visual issues when using a semi-transparent background color
- Added padding on gearset buttons in the gearset popup to avoid cutoff with the scrollbar
- Added configurable background color for tooltips
- Removed the 4 pixels margin on auxiliary bars that caused a small offset on the horizontal positioning.

> Depends on https://github.com/una-xiv/drawing/pull/18