### PR TITLE
Hide auxbars when hiding game UI

### DIFF
--- a/Umbra/src/Toolbar/Toolbar.cs
+++ b/Umbra/src/Toolbar/Toolbar.cs
@@ -8,14 +8,16 @@ internal sealed partial class Toolbar(AuxBarManager auxBars, IPlayer player, Umb
     [OnDraw(executionOrder: int.MaxValue)]
     private void DrawToolbar()
     {
+        if (!visibility.IsToolbarVisible()) return;
+
         UpdateToolbarWidth();
         UpdateToolbarNodeClassList();
         UpdateToolbarAutoHideOffset();
 
-        if (Enabled && visibility.IsToolbarVisible()) {
+        if (Enabled) {
             RenderToolbarNode();
         }
-        
+
         RenderAuxBarNodes();
     }
 


### PR DESCRIPTION
This fix a regression where the auxiliary bars does not hide when hiding game UI