### PR TITLE
Add support for Deep Dungeon Treasure Coffers

### DIFF
--- a/Umbra/src/Markers/Library/TreasureCofferMarkerFactory.cs
+++ b/Umbra/src/Markers/Library/TreasureCofferMarkerFactory.cs
@@ -62,5 +62,3 @@ internal class TreasureCofferMarkerFactory(IObjectTable objectTable, IZoneManage
         RemoveMarkersExcept(usedIds);
     }
 }
-
-


### PR DESCRIPTION
This PR adds support for the Gold, Silver and Banded treasure coffers within the various Deep Dungeons within the game, since these are not listed under the Treasure game object but rather as EventObj. It also limits the EventObj check to just the baseIDs of the treasure coffers found within these dungeons so it doesn't end up showing other things (i.e. Altar of Return). 