### PR TITLE
feat: Add DTR entry name to DtrSingleWidget

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/DtrSingle/DtrSingleWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/DtrSingle/DtrSingleWidget.cs
@@ -74,7 +74,7 @@ internal partial class DtrSingleWidget(
     public override string GetInstanceName()
     {
         string title = GetConfigValue<string>("SelectedEntry");
-        return title.Length > 1 ? $"{base.GetInstanceName()} - {title}" : base.GetInstanceName();
+        return title.Length > 0 ? $"{base.GetInstanceName()} - {title}" : base.GetInstanceName();
     }
 
     private void OnLeftClick(Node _)


### PR DESCRIPTION
Example with my Ping server bar widget:

<img width="512" height="63" alt="image" src="https://github.com/user-attachments/assets/137305d5-7b61-408b-97d4-b7445d3c5b84" />

If no entry is selected, it will just default to the original widget name.

> Ref: https://discord.com/channels/1263935915517149298/1425571776796168272