### PR TITLE
Fixed width for the Emote Chat Indicator Widget

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/EmoteChatIndicator/EmoteChatIndicatorWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/EmoteChatIndicator/EmoteChatIndicatorWidget.cs
@@ -16,6 +16,9 @@ internal class EmoteChatIndicatorWidget(
 
     private IGameConfig GameConfig { get; } = Framework.Service<IGameConfig>();
 
+    protected override string DefaultSizingMode => SizingModeFixed;
+    protected override int    DefaultWidth      => 32;
+
     protected override IEnumerable<IWidgetConfigVariable> GetConfigVariables()
     {
         return [


### PR DESCRIPTION
This aligns with how the Volume Widget works

> Ref: https://discord.com/channels/1263935915517149298/1280310559429890048