### PR TITLE
Dynamic Menu: Hide 'Move to Top' and 'Move to Bottom' context menu entries

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/DynamicMenu/DynamicMenuPopup.ContextMenu.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/DynamicMenu/DynamicMenuPopup.ContextMenu.cs
@@ -117,8 +117,10 @@ internal sealed partial class DynamicMenuPopup
         ContextMenu!.SetEntryVisible("DisableEditMode", EditModeEnabled);
         ContextMenu!.SetEntryVisible("EnableEditMode",  !EditModeEnabled);
         ContextMenu!.SetEntryVisible("Configure",       itemIndex != null);
+        ContextMenu!.SetEntryVisible("MoveToTop",       itemIndex != null);
         ContextMenu!.SetEntryVisible("MoveUp",          itemIndex != null);
         ContextMenu!.SetEntryVisible("MoveDown",        itemIndex != null);
+        ContextMenu!.SetEntryVisible("MoveToBottom",    itemIndex != null);
         ContextMenu!.SetEntryVisible("Remove",          itemIndex != null);
 
         if (itemIndex != null) {


### PR DESCRIPTION
This was not causing any crash, but was creating a lot of errors in the log.