### PR TITLE
Fix: Prevent IndexOutOfRangeException in UnifiedMainMenu for names without spaces

### DIFF
--- a/Umbra/src/Toolbar/Widgets/Library/UnifiedMainMenu/UnifiedMainMenuPopup.Header.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/UnifiedMainMenu/UnifiedMainMenuPopup.Header.cs
@@ -42,16 +42,4 @@ internal sealed partial class UnifiedMainMenuPopup
         headNode.Style.BackgroundGradient = IsTopAligned ? new(color2, color1) : new(color1, color2);
         headNode.ToggleClass("is-top", IsTopAligned);
     }
-
-    private static string GetInitials(string fName, string lName)
-    {
-        char fInitial = !string.IsNullOrEmpty(fName) ? fName[0] : '?';
-
-        if (string.IsNullOrEmpty(lName)) {
-            return $"{fInitial}.";
-        }
-
-        char lInitial = lName[0];
-        return $"{fInitial}. {lInitial}.";
-    }
 }

--- a/Umbra/src/Toolbar/Widgets/Library/UnifiedMainMenu/UnifiedMainMenuPopup.Header.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/UnifiedMainMenu/UnifiedMainMenuPopup.Header.cs
@@ -16,15 +16,12 @@ internal sealed partial class UnifiedMainMenuPopup
 
         string[] name = Player.Name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
-        string firstName = name.Length > 0 ? name[0] : Player.Name;
-        string lastName = name.Length > 1 ? name[1] : string.Empty;
-
         nameNode.NodeValue = BannerNameStyle switch {
-            "FirstName" => firstName,
-            "LastName" => string.IsNullOrEmpty(lastName) ? firstName : lastName,
-            "FullName" => string.IsNullOrEmpty(lastName) ? firstName : $"{firstName} {lastName}",
-            "Initials" => GetInitials(firstName, lastName),
-            _ => Player.Name
+            "FirstName" => name[0],
+            "LastName"  => name[^1],
+            "FullName"  => name.Length > 1 ? $"{name[0]} {name[1]}" : name[0],
+            "Initials"  => name.Length > 1 ? $"{name[0][0]}. {name[1][0]}." : $"{name[0][0]}.",
+            _           => Player.Name
         };
 
         StringBuilder sb = new();
@@ -44,17 +41,5 @@ internal sealed partial class UnifiedMainMenuPopup
         Node.Style.FlowOrder              = IsTopAligned ? FlowOrder.Normal : FlowOrder.Reverse;
         headNode.Style.BackgroundGradient = IsTopAligned ? new(color2, color1) : new(color1, color2);
         headNode.ToggleClass("is-top", IsTopAligned);
-    }
-
-    private static string GetInitials(string fName, string lName)
-    {
-        char fInitial = !string.IsNullOrEmpty(fName) ? fName[0] : '?';
-
-        if (string.IsNullOrEmpty(lName)) {
-            return $"{fInitial}.";
-        }
-
-        char lInitial = lName[0];
-        return $"{fInitial}. {lInitial}.";
     }
 }

--- a/Umbra/src/Toolbar/Widgets/Library/UnifiedMainMenu/UnifiedMainMenuPopup.Header.cs
+++ b/Umbra/src/Toolbar/Widgets/Library/UnifiedMainMenu/UnifiedMainMenuPopup.Header.cs
@@ -14,14 +14,17 @@ internal sealed partial class UnifiedMainMenuPopup
         JobInfo jobInfo = Player.GetJobInfo(Player.JobId);
         iconNode.Style.IconId = AvatarIconId;
 
-        string[] name = Player.Name.Split(' ');
-        
+        string[] name = Player.Name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        string firstName = name.Length > 0 ? name[0] : Player.Name;
+        string lastName = name.Length > 1 ? name[1] : string.Empty;
+
         nameNode.NodeValue = BannerNameStyle switch {
-            "FirstName" => $"{name[0]}",
-            "LastName"  => $"{name[1]}",
-            "FullName"  => $"{name[0]} {name[1]}",
-            "Initials"  => $"{name[0][0]}. {name[1][0]}.",
-            _           => Player.Name
+            "FirstName" => firstName,
+            "LastName" => string.IsNullOrEmpty(lastName) ? firstName : lastName,
+            "FullName" => string.IsNullOrEmpty(lastName) ? firstName : $"{firstName} {lastName}",
+            "Initials" => GetInitials(firstName, lastName),
+            _ => Player.Name
         };
 
         StringBuilder sb = new();
@@ -37,9 +40,21 @@ internal sealed partial class UnifiedMainMenuPopup
             "RoleColor"   => new(Player.GetJobInfo(Player.JobId).ColorName),
             _             => new(0),
         };
-        
+
         Node.Style.FlowOrder              = IsTopAligned ? FlowOrder.Normal : FlowOrder.Reverse;
         headNode.Style.BackgroundGradient = IsTopAligned ? new(color2, color1) : new(color1, color2);
         headNode.ToggleClass("is-top", IsTopAligned);
+    }
+
+    private static string GetInitials(string fName, string lName)
+    {
+        char fInitial = !string.IsNullOrEmpty(fName) ? fName[0] : '?';
+
+        if (string.IsNullOrEmpty(lName)) {
+            return $"{fInitial}.";
+        }
+
+        char lInitial = lName[0];
+        return $"{fInitial}. {lInitial}.";
     }
 }


### PR DESCRIPTION
(AI translated from Chinese)

## Description
This PR fixes an `IndexOutOfRangeException` that occurs in `UnifiedMainMenuPopup.UpdateHeaderNodes()` when parsing the player's name. 

Currently, the code assumes `Player.Name.Split(' ')` will always return an array with at least two elements. If a player has a name without spaces, accessing `name[1]` for the `LastName`, `FullName`, or `Initials` styles throws an exception, breaking the UI rendering.

This fix introduces bounds checking and provides safe fallbacks, ensuring that if a name only contains a single word, the widget defaults to displaying that word gracefully without crashing.

## Motivation and Context
While two-part names (First Last) are mandatory in the Global client of FFXIV, other regions (such as the CN server) allow single-word names. This causes the Unified Main Menu to crash upon opening for those players. This fix makes the parsing logic more robust for all edge cases.

## How Has This Been Tested?
- [x] Tested locally on the **FFXIV Chinese (CN) Client**, where single-word names are natively supported. Verified that the menu opens successfully and the name formats fallback correctly.
   <img width="912" height="650" alt="image" src="https://github.com/user-attachments/assets/016da1b8-66df-42be-a88e-9acd7f3c9266" />

- [x] **Note for Reviewers:** I have *not* tested this against the **Global Client**. However, since the fix only introduces bounds checking, it should be strictly backward compatible with standard Global names. Global client verification would be appreciated.