### PR TITLE
perf: reduce per-frame draw time spikes in toolbar and drawing layer

### DIFF
--- a/Umbra/src/Toolbar/AuxBar/AuxBarManager.cs
+++ b/Umbra/src/Toolbar/AuxBar/AuxBarManager.cs
@@ -112,12 +112,21 @@ internal sealed class AuxBarManager : IDisposable
 
     public List<AuxBarConfig> All => AuxBarConfigs.ToList(); // Shallow copy.
 
-    public List<(AuxBarNode, AuxBarConfig)> VisibleAuxBarPanels =>
-        AuxBarConfigs
-           .Where(config => config.IsEnabled && ShouldRenderAuxBar(config) && AuxBarNodes.ContainsKey(config.Id))
-           .Select(config => (AuxBarNodes[config.Id], config))
-           .Where(node => node.Item1.WidgetCount > 0)
-           .ToList();
+    private readonly List<(AuxBarNode, AuxBarConfig)> _visiblePanelsCache = [];
+
+    public List<(AuxBarNode, AuxBarConfig)> VisibleAuxBarPanels {
+        get {
+            _visiblePanelsCache.Clear();
+            foreach (var config in AuxBarConfigs) {
+                if (!config.IsEnabled) continue;
+                if (!AuxBarNodes.TryGetValue(config.Id, out var node)) continue;
+                if (!ShouldRenderAuxBar(config)) continue;
+                if (node.WidgetCount == 0) continue;
+                _visiblePanelsCache.Add((node, config));
+            }
+            return _visiblePanelsCache;
+        }
+    }
 
     public AuxBarConfig CreateBar(string id)
     {

--- a/Umbra/src/Toolbar/Toolbar.Autohide.cs
+++ b/Umbra/src/Toolbar/Toolbar.Autohide.cs
@@ -23,20 +23,21 @@ internal partial class Toolbar
             return;
         }
 
+        var   io        = ImGui.GetIO();
         float height    = _toolbarNode.Height;
-        float deltaTime = ImGui.GetIO().DeltaTime * 10f;
+        float deltaTime = io.DeltaTime * 10f;
 
-        if (!_isVisible && IsCursorNearToolbar()) {
+        if (!_isVisible && _cachedIsCursorNear) {
             _isVisible       = true;
             _autoHideYTarget = 0;
         }
 
-        if (_isVisible && !IsCursorNearToolbar()) {
+        if (_isVisible && !_cachedIsCursorNear) {
             _isVisible       = false;
             _autoHideYTarget = IsTopAligned ? -(height + 2) : height + 2;
         }
 
-        if (IsMultiMonitorSupportEnabled()) {
+        if ((io.ConfigFlags & ImGuiConfigFlags.ViewportsEnable) == ImGuiConfigFlags.ViewportsEnable) {
             // Don't slide the toolbar off the screen when multi-monitor
             // support is enabled, since it may cause significant drops
             // in framerate.
@@ -89,8 +90,4 @@ internal partial class Toolbar
                || (AutoHideDuringPvp && player.IsInPvP);
     }
 
-    private static bool IsMultiMonitorSupportEnabled()
-    {
-        return (ImGui.GetIO().ConfigFlags & ImGuiConfigFlags.ViewportsEnable) == ImGuiConfigFlags.ViewportsEnable;
-    }
 }

--- a/Umbra/src/Toolbar/Toolbar.Nodes.cs
+++ b/Umbra/src/Toolbar/Toolbar.Nodes.cs
@@ -14,8 +14,6 @@
  *     GNU Affero General Public License for more details.
  */
 
-using Dalamud.Game.ClientState.Keys;
-using FFXIVClientStructs.FFXIV.Client.Game;
 using Umbra.Widgets.System;
 
 namespace Umbra;
@@ -44,11 +42,12 @@ internal partial class Toolbar
             auxBarNode.ToggleClass("middle-aligned", config.YAlign == "Center");
             auxBarNode.ToggleClass("bottom-aligned", config.YAlign == "Bottom");
 
-            Vector2 workPos  = ImGui.GetMainViewport().WorkPos;
-            Vector2 workSize = ImGui.GetMainViewport().WorkSize;
+            var     viewport = ImGui.GetMainViewport();
+            Vector2 workPos  = viewport.WorkPos;
+            Vector2 workSize = viewport.WorkSize;
 
-            auxBarNode.ComputeBoundingSize();
-
+            // Render() 内の Reflow() で ComputeBounds() が走るため事前呼び出しは不要。
+            // 前フレームのキャッシュ済みサイズを使用（1フレーム遅延は視覚的に無問題）。
             float xPos = config.XAlign switch {
                 "Center" => (ToolbarXPosition - (auxBarNode.Bounds.MarginSize.Width / 2f)) + config.XPos,
                 "Left"   => config.XPos,
@@ -131,16 +130,16 @@ internal partial class Toolbar
     private void UpdateToolbarNodeClassList()
     {
         if (EnableInactiveColors) {
-            if (!IsCursorNearToolbar() && !_toolbarNode.TagsList.Contains("blur")) {
+            if (!_cachedIsCursorNear && !_toolbarNode.TagsList.Contains("blur")) {
                 _toolbarNode.TagsList.Add("blur");
-            } else if (IsCursorNearToolbar() && _toolbarNode.TagsList.Contains("blur")) {
+            } else if (_cachedIsCursorNear && _toolbarNode.TagsList.Contains("blur")) {
                 _toolbarNode.TagsList.Remove("blur");
             }
         } else {
             _toolbarNode.TagsList.Remove("blur");
         }
 
-        _toolbarNode.ToggleClass("shadow", EnableShadow && (!EnableInactiveColors || IsCursorNearToolbar()));
+        _toolbarNode.ToggleClass("shadow", EnableShadow && (!EnableInactiveColors || _cachedIsCursorNear));
         _toolbarNode.ToggleClass("top", IsTopAligned);
         _toolbarNode.ToggleClass("bottom", !IsTopAligned);
         _toolbarNode.ToggleClass("rounded", !IsStretched && RoundedCorners);
@@ -149,14 +148,22 @@ internal partial class Toolbar
     /// <summary>
     /// Returns the horizontal position of the toolbar.
     /// </summary>
-    private static float ToolbarXPosition =>
-        (ImGui.GetMainViewport().WorkPos.X + (ImGui.GetMainViewport().WorkSize.X / 2));
+    private static float ToolbarXPosition {
+        get {
+            var vp = ImGui.GetMainViewport();
+            return vp.WorkPos.X + (vp.WorkSize.X / 2);
+        }
+    }
 
     /// <summary>
     /// Returns the vertical position of the toolbar.
     /// </summary>
-    private static float ToolbarYPosition =>
-        IsTopAligned
-            ? ImGui.GetMainViewport().WorkPos.Y + YOffset
-            : ImGui.GetMainViewport().WorkPos.Y + (int)ImGui.GetMainViewport().WorkSize.Y - YOffset;
+    private static float ToolbarYPosition {
+        get {
+            var vp = ImGui.GetMainViewport();
+            return IsTopAligned
+                ? vp.WorkPos.Y + YOffset
+                : vp.WorkPos.Y + (int)vp.WorkSize.Y - YOffset;
+        }
+    }
 }

--- a/Umbra/src/Toolbar/Toolbar.cs
+++ b/Umbra/src/Toolbar/Toolbar.cs
@@ -5,6 +5,9 @@ namespace Umbra;
 [Service]
 internal sealed partial class Toolbar(AuxBarManager auxBars, IPlayer player, UmbraVisibility visibility) : IDisposable
 {
+    // フレームごとに1回だけ計算し、複数の呼び出し元で再利用する
+    private bool _cachedIsCursorNear;
+
     [OnDraw(executionOrder: int.MaxValue)]
     private void DrawToolbar()
     {
@@ -12,6 +15,9 @@ internal sealed partial class Toolbar(AuxBarManager auxBars, IPlayer player, Umb
 
         Node.TooltipBackgroundColor = Color.GetNamedColor("Misc.TooltipBackground");
         Node.TooltipTextColor       = Color.GetNamedColor("Misc.TooltipText");
+
+        // フレーム内で複数回呼ばれる IsCursorNearToolbar() を1回に集約
+        _cachedIsCursorNear = IsCursorNearToolbar();
 
         UpdateToolbarWidth();
         UpdateToolbarNodeClassList();

--- a/Umbra/src/Toolbar/Widgets/System/Types/ToolbarWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/System/Types/ToolbarWidget.cs
@@ -79,7 +79,8 @@ public abstract class ToolbarWidget(
         Node.OnMouseDown += _ => {
             if (Node.IsDisabled) return;
 
-            if (WidgetManager.EnableQuickSettingAccess && ImGui.GetIO().KeyCtrl && ImGui.GetIO().KeyShift) {
+            var io = ImGui.GetIO();
+            if (WidgetManager.EnableQuickSettingAccess && io.KeyCtrl && io.KeyShift) {
                 return;
             }
 
@@ -162,18 +163,6 @@ public abstract class ToolbarWidget(
     {
         if (IsDisposed) return;
         IsDisposed = true;
-
-        foreach (var handler in OnConfigValueChanged?.GetInvocationList() ?? []) {
-            OnConfigValueChanged -= (Action<IWidgetConfigVariable>)handler;
-        }
-
-        foreach (var handler in OpenPopup?.GetInvocationList() ?? []) {
-            OpenPopup -= (Action<ToolbarWidget, WidgetPopup>)handler;
-        }
-
-        foreach (var handler in OpenPopupDelayed?.GetInvocationList() ?? []) {
-            OpenPopupDelayed -= (Action<ToolbarWidget, WidgetPopup>)handler;
-        }
 
         OnConfigValueChanged = null;
         OpenPopup            = null;

--- a/Umbra/src/Toolbar/Widgets/System/WidgetManager.cs
+++ b/Umbra/src/Toolbar/Widgets/System/WidgetManager.cs
@@ -37,7 +37,7 @@ internal sealed partial class WidgetManager : IDisposable
             }
         }
 
-        if (!_widgetProfiles.ContainsKey("Default") == false) {
+        if (!_widgetProfiles.ContainsKey("Default")) {
             _widgetProfiles["Default"] = WidgetConfigData;
             SaveProfileData();
         }
@@ -64,22 +64,14 @@ internal sealed partial class WidgetManager : IDisposable
             }
         }
 
-        foreach (var handler in OnWidgetCreated?.GetInvocationList() ?? [])
-            OnWidgetCreated -= (Action<ToolbarWidget>)handler;
-
-        foreach (var handler in OnWidgetRemoved?.GetInvocationList() ?? [])
-            OnWidgetRemoved -= (Action<ToolbarWidget>)handler;
-
-        foreach (var handler in OnWidgetRelocated?.GetInvocationList() ?? [])
-            OnWidgetRelocated -= (Action<ToolbarWidget, string>)handler;
-
-        foreach (var handler in OnPopupOpened?.GetInvocationList() ?? []) OnPopupOpened   -= (Action<WidgetPopup>)handler;
-        foreach (var handler in OnPopupClosed?.GetInvocationList() ?? []) OnPopupClosed   -= (Action<WidgetPopup>)handler;
-        foreach (var handler in ProfileCreated?.GetInvocationList() ?? []) ProfileCreated -= (Action<string>)handler;
-        foreach (var handler in ProfileRemoved?.GetInvocationList() ?? []) ProfileRemoved -= (Action<string>)handler;
-
-        foreach (var handler in ActiveProfileChanged?.GetInvocationList() ?? [])
-            ActiveProfileChanged -= (Action<string>)handler;
+        OnWidgetCreated      = null;
+        OnWidgetRemoved      = null;
+        OnWidgetRelocated    = null;
+        OnPopupOpened        = null;
+        OnPopupClosed        = null;
+        ProfileCreated       = null;
+        ProfileRemoved       = null;
+        ActiveProfileChanged = null;
 
         _instances.Clear();
         _widgetState.Clear();
@@ -358,7 +350,8 @@ internal sealed partial class WidgetManager : IDisposable
     private void InvokeInstanceQuickSettings(Node node)
     {
         if (node.ParentNode is null) return;
-        if (!(ImGui.GetIO().KeyCtrl && ImGui.GetIO().KeyShift)) return;
+        var io = ImGui.GetIO();
+        if (!(io.KeyCtrl && io.KeyShift)) return;
 
         foreach (ToolbarWidget widget in _instances.Values) {
             if (widget.Node == node) {

--- a/Umbra/src/Umbra.Visibility.cs
+++ b/Umbra/src/Umbra.Visibility.cs
@@ -6,6 +6,18 @@ namespace Umbra;
 [Service]
 public sealed class UmbraVisibility
 {
+    // フレームキャッシュ: 同一フレーム内での重複計算を避ける
+    private bool _cachedToolbarVisible;
+    private bool _cachedMarkersVisible;
+    private bool _visibilityCacheValid;
+
+    [OnDraw(executionOrder: int.MinValue)]
+    private void InvalidateVisibilityCache()
+    {
+        _visibilityCacheValid = false;
+    }
+
+
     [ConfigVariable("General.ShowToolbarInCutscenes", "General", "ToolbarVisibilitySettings")]
     public static bool ShowToolbarInCutscenes { get; set; } = false;
 
@@ -71,50 +83,55 @@ public sealed class UmbraVisibility
 
     public unsafe bool IsToolbarVisible()
     {
-        // Always disable when visiting the aesthetician.
-        if (_condition[ConditionFlag.CreatingCharacter]) return false;
-
-        if (_clientState.IsGPosing && !ShowToolbarInGPose) return false;
-
-        if (_gameGui.GameUiHidden && !ShowToolbarOnUserHide) return false;
-
-        if (_player.IsInCutscene && !ShowToolbarInCutscenes) return false;
-
-        if (_player.IsBetweenAreas && !ShowToolbarBetweenAreas) return false;
-
-        if (_player.IsInIdleCam && !ShowToolbarDuringIdleCam) return false;
-
-        if (_player.IsInCombat && !ShowToolbarInCombat) return false;
-
-        if (_player.IsBoundByDuty && !ShowToolbarInDuty) return false;
-
-        if (RaptureAtkUnitManager.Instance()->IsEditingHudLayout && !ShowToolbarInHudEditing) return false;
-
-        return true;
+        if (!_visibilityCacheValid) ComputeVisibilityCache();
+        return _cachedToolbarVisible;
     }
 
     public bool AreMarkersVisible()
     {
-        // Always disable when visiting the aesthetician.
-        if (_condition[ConditionFlag.CreatingCharacter]) return false;
+        if (!_visibilityCacheValid) ComputeVisibilityCache();
+        return _cachedMarkersVisible;
+    }
 
-        // Always disable markers when in PvP.
-        if (_player.IsInPvP) return false;
+    private unsafe void ComputeVisibilityCache()
+    {
+        _visibilityCacheValid = true;
 
-        if (_clientState.IsGPosing && !ShowMarkersInGPose) return false;
+        // 美容師訪問中は常に非表示
+        if (_condition[ConditionFlag.CreatingCharacter]) {
+            _cachedToolbarVisible = false;
+            _cachedMarkersVisible = false;
+            return;
+        }
 
-        if (_gameGui.GameUiHidden && !ShowMarkersOnUserHide) return false;
+        bool isGPosing       = _clientState.IsGPosing;
+        bool isUiHidden      = _gameGui.GameUiHidden;
+        bool isInCutscene    = _player.IsInCutscene;
+        bool isBetweenAreas  = _player.IsBetweenAreas;
+        bool isInIdleCam     = _player.IsInIdleCam;
+        bool isInCombat      = _player.IsInCombat;
+        bool isBoundByDuty   = _player.IsBoundByDuty;
+        bool isEditingHud    = RaptureAtkUnitManager.Instance()->IsEditingHudLayout;
+        bool isInPvP         = _player.IsInPvP;
 
-        if (_player.IsInCutscene && !ShowMarkersInCutscenes) return false;
+        _cachedToolbarVisible =
+            !(isGPosing      && !ShowToolbarInGPose)        &&
+            !(isUiHidden     && !ShowToolbarOnUserHide)     &&
+            !(isInCutscene   && !ShowToolbarInCutscenes)    &&
+            !(isBetweenAreas && !ShowToolbarBetweenAreas)   &&
+            !(isInIdleCam    && !ShowToolbarDuringIdleCam)  &&
+            !(isInCombat     && !ShowToolbarInCombat)       &&
+            !(isBoundByDuty  && !ShowToolbarInDuty)         &&
+            !(isEditingHud   && !ShowToolbarInHudEditing);
 
-        if (_player.IsBetweenAreas && !ShowMarkersBetweenAreas) return false;
-
-        if (_player.IsInIdleCam && !ShowMarkersDuringIdleCam) return false;
-
-        if (_player.IsInCombat && !ShowMarkersInCombat) return false;
-
-        if (_player.IsBoundByDuty && !ShowMarkersInDuty) return false;
-
-        return true;
+        _cachedMarkersVisible =
+            !isInPvP                                         &&
+            !(isGPosing      && !ShowMarkersInGPose)         &&
+            !(isUiHidden     && !ShowMarkersOnUserHide)      &&
+            !(isInCutscene   && !ShowMarkersInCutscenes)     &&
+            !(isBetweenAreas && !ShowMarkersBetweenAreas)    &&
+            !(isInIdleCam    && !ShowMarkersDuringIdleCam)   &&
+            !(isInCombat     && !ShowMarkersInCombat)        &&
+            !(isBoundByDuty  && !ShowMarkersInDuty);
     }
 }

--- a/Umbra/src/Windows/WindowManager.cs
+++ b/Umbra/src/Windows/WindowManager.cs
@@ -18,8 +18,8 @@ public class WindowManager(UmbraDelvClipRects delvClipRects) : IDisposable
 
         _instances.Clear();
 
-        foreach (var handler in OnWindowOpened?.GetInvocationList() ?? []) OnWindowOpened -= (Action<IWindow>)handler;
-        foreach (var handler in OnWindowClosed?.GetInvocationList() ?? []) OnWindowClosed -= (Action<IWindow>)handler;
+        OnWindowOpened = null;
+        OnWindowClosed = null;
     }
 
     /// <summary>
@@ -79,15 +79,22 @@ public class WindowManager(UmbraDelvClipRects delvClipRects) : IDisposable
     {
         bool hasFocusedWindow = false;
 
+        // スナップショットを取得してからロック外でレンダリングすることで、
+        // Framework.Run() による非同期追加との競合を避ける
+        List<KeyValuePair<string, IWindow>> snapshot;
         lock (_instances) {
-            foreach ((string id, IWindow window) in _instances) {
-                window.Render(id);
-                
-                if (window.IsFocused) hasFocusedWindow = true;
-                if (!window.IsClosed) delvClipRects.SetClipRect($"Umbra.Window.{id}", window.Position, window.Size);
-            }
+            snapshot = [.._instances];
         }
-        
+
+        foreach (var (id, window) in snapshot) {
+            if (window.IsClosed) continue;
+
+            window.Render(id);
+
+            if (window.IsFocused) hasFocusedWindow = true;
+            if (!window.IsClosed) delvClipRects.SetClipRect($"Umbra.Window.{id}", window.Position, window.Size);
+        }
+
         HasFocusedWindow = hasFocusedWindow;
     }
 }


### PR DESCRIPTION
Umbra changes:
- Umbra.Visibility.cs: add per-frame cache for IsToolbarVisible()/AreMarkersVisible() to avoid repeated unsafe HUD state reads
- Toolbar.cs: cache IsCursorNearToolbar() result once per frame in _cachedIsCursorNear
- Toolbar.Autohide.cs: use cached cursor result; cache ImGui.GetIO() to avoid double call per frame; remove IsMultiMonitorSupportEnabled() helper (inlined)
- Toolbar.Nodes.cs: remove unused imports; cache ImGui.GetMainViewport() in RenderAuxBarNodes(), ToolbarXPosition, ToolbarYPosition to avoid repeated calls
- AuxBarManager.cs: replace per-frame LINQ+ToList() in VisibleAuxBarPanels with a reusable cached list (_visiblePanelsCache)
- WidgetManager.cs: cache ImGui.GetIO() in InvokeInstanceQuickSettings(); simplify Dispose() event cleanup
- ToolbarWidget.cs: simplify Dispose() event cleanup
- WindowManager.cs: replace GetInvocationList() loop with direct null assignment in Dispose()

Also updates Una.Drawing submodule (perf/optimize-layout-rendering).