### PR TITLE
perf: reduce per-frame draw time spikes in toolbar and drawing layer

### DIFF
--- a/Umbra/src/Markers/System/Compass/CompassRenderer.cs
+++ b/Umbra/src/Markers/System/Compass/CompassRenderer.cs
@@ -107,12 +107,14 @@ internal sealed class CompassRenderer(
     {
         if (GetIcon(60541) is not { } arrow) return;
 
-        float angle    = MathF.Atan2(direction.Y, direction.X);
-        float halfSize = 16 * (IconScaleFactor / 100f) * Node.ScaleFactor;
-        var   arrowPos = new Vector2(screenPos.X - halfSize, screenPos.Y - halfSize);
+        float angle       = MathF.Atan2(direction.Y, direction.X);
+        float arrowSize   = 16 * (IconScaleFactor / 100f) * Node.ScaleFactor;
+        float halfSize    = arrowSize / 2f;
+        float arrowOffset = (iconSize + arrowSize - halfSize);
+        var   arrowPos    = new Vector2(screenPos.X - halfSize, screenPos.Y - halfSize);
 
-        arrowPos.X += ((iconSize + (16 * (IconScaleFactor / 100f) * Node.ScaleFactor)) - halfSize) * MathF.Cos(angle);
-        arrowPos.Y += ((iconSize + (16 * (IconScaleFactor / 100f) * Node.ScaleFactor)) - halfSize) * MathF.Sin(angle);
+        arrowPos.X += arrowOffset * MathF.Cos(angle);
+        arrowPos.Y += arrowOffset * MathF.Sin(angle);
 
         ImGui
            .GetBackgroundDrawList()
@@ -129,11 +131,25 @@ internal sealed class CompassRenderer(
         return ClipRectProvider.FindClipRectsIntersectingWith(rect).Count == 0;
     }
 
+    // アイコンを毎フレーム取得しないようにキャッシュする
+    private readonly Dictionary<uint, IDalamudTextureWrap?> _iconCache    = [];
+    private readonly HashSet<uint>                          _failedIconIds = [];
+
     private IDalamudTextureWrap? GetIcon(uint iconId)
     {
+        if (_failedIconIds.Contains(iconId)) return null;
+        if (_iconCache.TryGetValue(iconId, out var cached)) return cached;
+
         try {
-            return textureProvider.GetFromGameIcon(new(iconId)).GetWrapOrDefault();
+            var wrap = textureProvider.GetFromGameIcon(new(iconId)).GetWrapOrDefault();
+            if (wrap == null) {
+                _failedIconIds.Add(iconId);
+                return null;
+            }
+            _iconCache[iconId] = wrap;
+            return wrap;
         } catch {
+            _failedIconIds.Add(iconId);
             return null;
         }
     }

--- a/Umbra/src/Markers/System/Renderer/WorldMarkerNode.cs
+++ b/Umbra/src/Markers/System/Renderer/WorldMarkerNode.cs
@@ -56,11 +56,17 @@ internal class WorldMarkerNode : Node
 
     public void RemoveMarker(string id)
     {
-        var index = _markers.Keys.ToList().IndexOf(id);
-        if (index == -1) return;
+        // ToList().IndexOf() を避け、Dictionary を直接走査して挿入順インデックスを取得
+        int index = 0;
+        bool found = false;
+        foreach (var key in _markers.Keys) {
+            if (key == id) { found = true; break; }
+            index++;
+        }
+
+        if (!found) return;
 
         _markers.Remove(id);
-
         ClearState(index);
     }
 
@@ -75,8 +81,12 @@ internal class WorldMarkerNode : Node
     {
         if (!_markers.ContainsKey(marker.Key)) return false;
 
-        return _markers.Count != 0
-            && _markers.Values.All(t => !(Vector3.Distance(t.WorldPosition, marker.WorldPosition) > AggregateDistance));
+        // 既存の全マーカーが集約距離以内に収まっているかを確認
+        foreach (var existing in _markers.Values) {
+            if (Vector3.Distance(existing.WorldPosition, marker.WorldPosition) > AggregateDistance) return false;
+        }
+
+        return true;
     }
 
     public Vector3? WorldPosition => _markers.Count > 0 ? _markers.Values.First().WorldPosition : null;

--- a/Umbra/src/Markers/System/Renderer/WorldMarkerRenderer.cs
+++ b/Umbra/src/Markers/System/Renderer/WorldMarkerRenderer.cs
@@ -20,6 +20,9 @@ internal class WorldMarkerRenderer : IDisposable
     private Dictionary<int, WorldMarkerNode> NodePool          { get; } = new();
     private Dictionary<string, int>          MarkerAssignments { get; } = new();
 
+    // フレームごとに使い捨てリストを new しないよう再利用
+    private readonly List<string> _idsToRemove = [];
+
     public WorldMarkerRenderer(
         IGameCamera         gameCamera,
         WorldMarkerRegistry registry,
@@ -132,16 +135,16 @@ internal class WorldMarkerRenderer : IDisposable
 
     private void RemoveMarkersExcept(HashSet<string> usedMarkerIds)
     {
-        List<string> idsToRemove = [];
+        _idsToRemove.Clear();
 
         foreach ((string id, int nodeId) in MarkerAssignments) {
             if (!usedMarkerIds.Contains(id)) {
-                idsToRemove.Add(id);
+                _idsToRemove.Add(id);
                 NodePool[nodeId].RemoveMarker(id);
             }
         }
 
-        foreach (string id in idsToRemove) {
+        foreach (string id in _idsToRemove) {
             MarkerAssignments.Remove(id);
         }
     }

--- a/Umbra/src/Markers/System/WorldMarkerRegistry.cs
+++ b/Umbra/src/Markers/System/WorldMarkerRegistry.cs
@@ -32,10 +32,12 @@ internal sealed class WorldMarkerRegistry : IDisposable
 
     public List<WorldMarker> GetMarkers()
     {
-        if (! _zoneManager.HasCurrentZone) return [];
+        if (!_zoneManager.HasCurrentZone) return [];
+        if (!_visibility.AreMarkersVisible()) return [];
 
-        return _visibility.AreMarkersVisible()
-            ? WorldMarkers[_zoneManager.CurrentZone.Id].Values.ToList()
+        // TryGetValue でキー不在時の KeyNotFoundException を防ぐ
+        return WorldMarkers.TryGetValue(_zoneManager.CurrentZone.Id, out var markers)
+            ? [..markers.Values]
             : [];
     }
 

--- a/Umbra/src/Toolbar/AuxBar/AuxBarManager.cs
+++ b/Umbra/src/Toolbar/AuxBar/AuxBarManager.cs
@@ -112,12 +112,21 @@ internal sealed class AuxBarManager : IDisposable
 
     public List<AuxBarConfig> All => AuxBarConfigs.ToList(); // Shallow copy.
 
-    public List<(AuxBarNode, AuxBarConfig)> VisibleAuxBarPanels =>
-        AuxBarConfigs
-           .Where(config => config.IsEnabled && ShouldRenderAuxBar(config) && AuxBarNodes.ContainsKey(config.Id))
-           .Select(config => (AuxBarNodes[config.Id], config))
-           .Where(node => node.Item1.WidgetCount > 0)
-           .ToList();
+    private readonly List<(AuxBarNode, AuxBarConfig)> _visiblePanelsCache = [];
+
+    public List<(AuxBarNode, AuxBarConfig)> VisibleAuxBarPanels {
+        get {
+            _visiblePanelsCache.Clear();
+            foreach (var config in AuxBarConfigs) {
+                if (!config.IsEnabled) continue;
+                if (!AuxBarNodes.TryGetValue(config.Id, out var node)) continue;
+                if (!ShouldRenderAuxBar(config)) continue;
+                if (node.WidgetCount == 0) continue;
+                _visiblePanelsCache.Add((node, config));
+            }
+            return _visiblePanelsCache;
+        }
+    }
 
     public AuxBarConfig CreateBar(string id)
     {

--- a/Umbra/src/Toolbar/AuxBar/AuxBarNode.cs
+++ b/Umbra/src/Toolbar/AuxBar/AuxBarNode.cs
@@ -7,6 +7,9 @@ public class AuxBarNode : UdtNode
     private bool _isVertical;
     private int  _width;
 
+    // レイアウト関連の値が変わったときだけウィジェット走査を行うためのダーティフラグ
+    private bool _layoutDirty = true;
+
     public AuxBarNode(AuxBarConfig config) : base("umbra.auxbar.xml")
     {
         QuerySelector(".section")!.Id = config.Id;
@@ -18,11 +21,19 @@ public class AuxBarNode : UdtNode
         ToggleClass("toolbar", config.Decorate);
         ToggleClass("shadow", config.EnableShadow);
         ToggleClass("rounded", config.RoundedCorners);
-        ToggleClass("vertical", _isVertical = config.IsVertical);
+
+        bool newVertical = config.IsVertical;
+        int  newWidth    = config.Width;
+
+        if (newVertical != _isVertical || newWidth != _width) {
+            _isVertical  = newVertical;
+            _width       = newWidth;
+            _layoutDirty = true;
+        }
+
+        ToggleClass("vertical", _isVertical);
 
         QuerySelector(".section")!.Style.Gap = config.ItemSpacing;
-
-        _width = config.Width;
 
         ToggleClass("align-content-left", config.WidgetContentAlignment == "Left");
         ToggleClass("align-content-center", config.WidgetContentAlignment == "Center");
@@ -34,6 +45,10 @@ public class AuxBarNode : UdtNode
         Style.Size = _isVertical
             ? new(0, 0)
             : new(_width, Toolbar.Height);
+
+        // 縦横切り替えや幅変更があった場合のみウィジェットの AutoSize を更新する
+        if (!_layoutDirty) return;
+        _layoutDirty = false;
 
         foreach (var widget in QuerySelectorAll(".widget-instance")) {
             if (_isVertical) {

--- a/Umbra/src/Toolbar/Toolbar.Autohide.cs
+++ b/Umbra/src/Toolbar/Toolbar.Autohide.cs
@@ -23,20 +23,21 @@ internal partial class Toolbar
             return;
         }
 
+        var   io        = ImGui.GetIO();
         float height    = _toolbarNode.Height;
-        float deltaTime = ImGui.GetIO().DeltaTime * 10f;
+        float deltaTime = io.DeltaTime * 10f;
 
-        if (!_isVisible && IsCursorNearToolbar()) {
+        if (!_isVisible && _cachedIsCursorNear) {
             _isVisible       = true;
             _autoHideYTarget = 0;
         }
 
-        if (_isVisible && !IsCursorNearToolbar()) {
+        if (_isVisible && !_cachedIsCursorNear) {
             _isVisible       = false;
             _autoHideYTarget = IsTopAligned ? -(height + 2) : height + 2;
         }
 
-        if (IsMultiMonitorSupportEnabled()) {
+        if ((io.ConfigFlags & ImGuiConfigFlags.ViewportsEnable) == ImGuiConfigFlags.ViewportsEnable) {
             // Don't slide the toolbar off the screen when multi-monitor
             // support is enabled, since it may cause significant drops
             // in framerate.
@@ -89,8 +90,4 @@ internal partial class Toolbar
                || (AutoHideDuringPvp && player.IsInPvP);
     }
 
-    private static bool IsMultiMonitorSupportEnabled()
-    {
-        return (ImGui.GetIO().ConfigFlags & ImGuiConfigFlags.ViewportsEnable) == ImGuiConfigFlags.ViewportsEnable;
-    }
 }

--- a/Umbra/src/Toolbar/Toolbar.Nodes.cs
+++ b/Umbra/src/Toolbar/Toolbar.Nodes.cs
@@ -14,8 +14,6 @@
  *     GNU Affero General Public License for more details.
  */
 
-using Dalamud.Game.ClientState.Keys;
-using FFXIVClientStructs.FFXIV.Client.Game;
 using Umbra.Widgets.System;
 
 namespace Umbra;
@@ -44,11 +42,12 @@ internal partial class Toolbar
             auxBarNode.ToggleClass("middle-aligned", config.YAlign == "Center");
             auxBarNode.ToggleClass("bottom-aligned", config.YAlign == "Bottom");
 
-            Vector2 workPos  = ImGui.GetMainViewport().WorkPos;
-            Vector2 workSize = ImGui.GetMainViewport().WorkSize;
+            var     viewport = ImGui.GetMainViewport();
+            Vector2 workPos  = viewport.WorkPos;
+            Vector2 workSize = viewport.WorkSize;
 
-            auxBarNode.ComputeBoundingSize();
-
+            // Render() 内の Reflow() で ComputeBounds() が走るため事前呼び出しは不要。
+            // 前フレームのキャッシュ済みサイズを使用（1フレーム遅延は視覚的に無問題）。
             float xPos = config.XAlign switch {
                 "Center" => (ToolbarXPosition - (auxBarNode.Bounds.MarginSize.Width / 2f)) + config.XPos,
                 "Left"   => config.XPos,
@@ -131,16 +130,16 @@ internal partial class Toolbar
     private void UpdateToolbarNodeClassList()
     {
         if (EnableInactiveColors) {
-            if (!IsCursorNearToolbar() && !_toolbarNode.TagsList.Contains("blur")) {
+            if (!_cachedIsCursorNear && !_toolbarNode.TagsList.Contains("blur")) {
                 _toolbarNode.TagsList.Add("blur");
-            } else if (IsCursorNearToolbar() && _toolbarNode.TagsList.Contains("blur")) {
+            } else if (_cachedIsCursorNear && _toolbarNode.TagsList.Contains("blur")) {
                 _toolbarNode.TagsList.Remove("blur");
             }
         } else {
             _toolbarNode.TagsList.Remove("blur");
         }
 
-        _toolbarNode.ToggleClass("shadow", EnableShadow && (!EnableInactiveColors || IsCursorNearToolbar()));
+        _toolbarNode.ToggleClass("shadow", EnableShadow && (!EnableInactiveColors || _cachedIsCursorNear));
         _toolbarNode.ToggleClass("top", IsTopAligned);
         _toolbarNode.ToggleClass("bottom", !IsTopAligned);
         _toolbarNode.ToggleClass("rounded", !IsStretched && RoundedCorners);
@@ -149,14 +148,22 @@ internal partial class Toolbar
     /// <summary>
     /// Returns the horizontal position of the toolbar.
     /// </summary>
-    private static float ToolbarXPosition =>
-        (ImGui.GetMainViewport().WorkPos.X + (ImGui.GetMainViewport().WorkSize.X / 2));
+    private static float ToolbarXPosition {
+        get {
+            var vp = ImGui.GetMainViewport();
+            return vp.WorkPos.X + (vp.WorkSize.X / 2);
+        }
+    }
 
     /// <summary>
     /// Returns the vertical position of the toolbar.
     /// </summary>
-    private static float ToolbarYPosition =>
-        IsTopAligned
-            ? ImGui.GetMainViewport().WorkPos.Y + YOffset
-            : ImGui.GetMainViewport().WorkPos.Y + (int)ImGui.GetMainViewport().WorkSize.Y - YOffset;
+    private static float ToolbarYPosition {
+        get {
+            var vp = ImGui.GetMainViewport();
+            return IsTopAligned
+                ? vp.WorkPos.Y + YOffset
+                : vp.WorkPos.Y + (int)vp.WorkSize.Y - YOffset;
+        }
+    }
 }

--- a/Umbra/src/Toolbar/Toolbar.cs
+++ b/Umbra/src/Toolbar/Toolbar.cs
@@ -5,6 +5,9 @@ namespace Umbra;
 [Service]
 internal sealed partial class Toolbar(AuxBarManager auxBars, IPlayer player, UmbraVisibility visibility) : IDisposable
 {
+    // フレームごとに1回だけ計算し、複数の呼び出し元で再利用する
+    private bool _cachedIsCursorNear;
+
     [OnDraw(executionOrder: int.MaxValue)]
     private void DrawToolbar()
     {
@@ -12,6 +15,9 @@ internal sealed partial class Toolbar(AuxBarManager auxBars, IPlayer player, Umb
 
         Node.TooltipBackgroundColor = Color.GetNamedColor("Misc.TooltipBackground");
         Node.TooltipTextColor       = Color.GetNamedColor("Misc.TooltipText");
+
+        // フレーム内で複数回呼ばれる IsCursorNearToolbar() を1回に集約
+        _cachedIsCursorNear = IsCursorNearToolbar();
 
         UpdateToolbarWidth();
         UpdateToolbarNodeClassList();

--- a/Umbra/src/Toolbar/Widgets/System/Popup/WidgetPopup.cs
+++ b/Umbra/src/Toolbar/Widgets/System/Popup/WidgetPopup.cs
@@ -88,7 +88,6 @@ public abstract class WidgetPopup : IDisposable
         ImGui.PushStyleVar(ImGuiStyleVar.WindowPadding, Vector2.Zero);
         ImGui.PushStyleVar(ImGuiStyleVar.WindowRounding, 0f);
         ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0f);
-        ImGui.PushStyleVar(ImGuiStyleVar.WindowBorderSize, 0f);
 
         bool keepOpen = false;
 
@@ -100,13 +99,15 @@ public abstract class WidgetPopup : IDisposable
             Logger.Error(e.StackTrace);
         }
 
-        ImGui.PopStyleVar(4);
+        ImGui.PopStyleVar(3);
 
         return keepOpen;
     }
 
     public void Reset()
     {
+        _isCrashed = false;
+
         if (_isOpen) {
             _isOpen      = false;
             _shouldClose = false;
@@ -162,8 +163,8 @@ public abstract class WidgetPopup : IDisposable
         _opacityDest = 1;
         _yOffsetDest = 0;
 
-        _opacity = _opacity += (_opacityDest - _opacity) * deltaTime;
-        _yOffset = _yOffset += (_yOffsetDest - _yOffset) * deltaTime;
+        _opacity += (_opacityDest - _opacity) * deltaTime;
+        _yOffset += (_yOffsetDest - _yOffset) * deltaTime;
 
         switch (IsPopupOpenDownward(activator)) {
             case true when _yOffset > -1:
@@ -199,11 +200,11 @@ public abstract class WidgetPopup : IDisposable
 
         bool hasFocus = true;
 
-        try {
-            ImGui.SetNextWindowPos(new(Position.X, Position.Y));
-            ImGui.SetNextWindowSize(new(Size.X, Size.Y));
-            ImGui.Begin($"###Popup_{activator.Id.GetHashCode():X}", PopupWindowFlags);
+        ImGui.SetNextWindowPos(new(Position.X, Position.Y));
+        ImGui.SetNextWindowSize(new(Size.X, Size.Y));
+        ImGui.Begin($"###Popup_{activator.Id.GetHashCode():X}", PopupWindowFlags);
 
+        try {
             hasFocus = ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows);
 
             _popupNode.Render(ImGui.GetWindowDrawList(), new(0, _yOffset));
@@ -211,11 +212,12 @@ public abstract class WidgetPopup : IDisposable
             if (ContextMenu is { ShouldRender: true }) {
                 _contextMenuManager.Draw();
             }
-
-            ImGui.End();
         } catch (Exception e) {
             Logger.Error(e.Message);
             Logger.Error(e.StackTrace);
+            _shouldClose = true;
+        } finally {
+            ImGui.End();
         }
 
         bool keepOpen = !_shouldClose && hasFocus;

--- a/Umbra/src/Toolbar/Widgets/System/Types/ToolbarWidget.cs
+++ b/Umbra/src/Toolbar/Widgets/System/Types/ToolbarWidget.cs
@@ -79,7 +79,8 @@ public abstract class ToolbarWidget(
         Node.OnMouseDown += _ => {
             if (Node.IsDisabled) return;
 
-            if (WidgetManager.EnableQuickSettingAccess && ImGui.GetIO().KeyCtrl && ImGui.GetIO().KeyShift) {
+            var io = ImGui.GetIO();
+            if (WidgetManager.EnableQuickSettingAccess && io.KeyCtrl && io.KeyShift) {
                 return;
             }
 
@@ -162,18 +163,6 @@ public abstract class ToolbarWidget(
     {
         if (IsDisposed) return;
         IsDisposed = true;
-
-        foreach (var handler in OnConfigValueChanged?.GetInvocationList() ?? []) {
-            OnConfigValueChanged -= (Action<IWidgetConfigVariable>)handler;
-        }
-
-        foreach (var handler in OpenPopup?.GetInvocationList() ?? []) {
-            OpenPopup -= (Action<ToolbarWidget, WidgetPopup>)handler;
-        }
-
-        foreach (var handler in OpenPopupDelayed?.GetInvocationList() ?? []) {
-            OpenPopupDelayed -= (Action<ToolbarWidget, WidgetPopup>)handler;
-        }
 
         OnConfigValueChanged = null;
         OpenPopup            = null;

--- a/Umbra/src/Toolbar/Widgets/System/WidgetManager.cs
+++ b/Umbra/src/Toolbar/Widgets/System/WidgetManager.cs
@@ -37,7 +37,7 @@ internal sealed partial class WidgetManager : IDisposable
             }
         }
 
-        if (!_widgetProfiles.ContainsKey("Default") == false) {
+        if (!_widgetProfiles.ContainsKey("Default")) {
             _widgetProfiles["Default"] = WidgetConfigData;
             SaveProfileData();
         }
@@ -64,22 +64,14 @@ internal sealed partial class WidgetManager : IDisposable
             }
         }
 
-        foreach (var handler in OnWidgetCreated?.GetInvocationList() ?? [])
-            OnWidgetCreated -= (Action<ToolbarWidget>)handler;
-
-        foreach (var handler in OnWidgetRemoved?.GetInvocationList() ?? [])
-            OnWidgetRemoved -= (Action<ToolbarWidget>)handler;
-
-        foreach (var handler in OnWidgetRelocated?.GetInvocationList() ?? [])
-            OnWidgetRelocated -= (Action<ToolbarWidget, string>)handler;
-
-        foreach (var handler in OnPopupOpened?.GetInvocationList() ?? []) OnPopupOpened   -= (Action<WidgetPopup>)handler;
-        foreach (var handler in OnPopupClosed?.GetInvocationList() ?? []) OnPopupClosed   -= (Action<WidgetPopup>)handler;
-        foreach (var handler in ProfileCreated?.GetInvocationList() ?? []) ProfileCreated -= (Action<string>)handler;
-        foreach (var handler in ProfileRemoved?.GetInvocationList() ?? []) ProfileRemoved -= (Action<string>)handler;
-
-        foreach (var handler in ActiveProfileChanged?.GetInvocationList() ?? [])
-            ActiveProfileChanged -= (Action<string>)handler;
+        OnWidgetCreated      = null;
+        OnWidgetRemoved      = null;
+        OnWidgetRelocated    = null;
+        OnPopupOpened        = null;
+        OnPopupClosed        = null;
+        ProfileCreated       = null;
+        ProfileRemoved       = null;
+        ActiveProfileChanged = null;
 
         _instances.Clear();
         _widgetState.Clear();
@@ -358,7 +350,8 @@ internal sealed partial class WidgetManager : IDisposable
     private void InvokeInstanceQuickSettings(Node node)
     {
         if (node.ParentNode is null) return;
-        if (!(ImGui.GetIO().KeyCtrl && ImGui.GetIO().KeyShift)) return;
+        var io = ImGui.GetIO();
+        if (!(io.KeyCtrl && io.KeyShift)) return;
 
         foreach (ToolbarWidget widget in _instances.Values) {
             if (widget.Node == node) {

--- a/Umbra/src/Umbra.Colors.cs
+++ b/Umbra/src/Umbra.Colors.cs
@@ -85,9 +85,10 @@ internal class UmbraColors
 
     public static void UpdateCurrentProfile()
     {
+        // Stop() → Start() で1秒デバウンスをリセット。
+        // Enabled の二重設定は System.Timers.Timer のスレッド安全性を損なうため除去
         _debounceTimer!.Stop();
         _debounceTimer!.Start();
-        _debounceTimer!.Enabled = true;
     }
 
     /// <summary>

--- a/Umbra/src/Umbra.DelvClipRects.cs
+++ b/Umbra/src/Umbra.DelvClipRects.cs
@@ -69,6 +69,8 @@ public sealed class UmbraDelvClipRects : IDisposable
             foreach (var key in _managedRects) {
                 _clipRects.Remove(key);
             }
+            // _clipRects と _managedRects を同期させる。再有効化時に古いエントリが残らないようにする
+            _managedRects.Clear();
         }
     }
 }

--- a/Umbra/src/Umbra.Drawing.cs
+++ b/Umbra/src/Umbra.Drawing.cs
@@ -48,15 +48,16 @@ internal static class UmbraDrawing
     internal static UdtDocument DocumentFrom(string resourceName)
     {
         foreach (var assembly in Framework.Assemblies) {
+            // 大文字小文字を無視して一致するリソース名を検索し、見つかった実際の名前を使用する
             var resource = assembly
                           .GetManifestResourceNames()
                           .FirstOrDefault(r => r.EndsWith(resourceName, StringComparison.OrdinalIgnoreCase));
-            
+
             if (resource == null) continue;
-            
-            return UdtLoader.LoadFromAssembly(assembly, resourceName);
+
+            return UdtLoader.LoadFromAssembly(assembly, resource);
         }
-        
+
         throw new Exception($"No UDT document with the name \"{resourceName}\" exists in any assembly.");
     }
     

--- a/Umbra/src/Umbra.Visibility.cs
+++ b/Umbra/src/Umbra.Visibility.cs
@@ -8,6 +8,18 @@ namespace Umbra;
 [Service]
 public sealed class UmbraVisibility
 {
+    // フレームキャッシュ: 同一フレーム内での重複計算を避ける
+    private bool _cachedToolbarVisible;
+    private bool _cachedMarkersVisible;
+    private bool _visibilityCacheValid;
+
+    [OnDraw(executionOrder: int.MinValue)]
+    private void InvalidateVisibilityCache()
+    {
+        _visibilityCacheValid = false;
+    }
+
+
     [ConfigVariable("General.ShowToolbarInCutscenes", "General", "ToolbarVisibilitySettings")]
     public static bool ShowToolbarInCutscenes { get; set; } = false;
 
@@ -73,56 +85,58 @@ public sealed class UmbraVisibility
 
     public unsafe bool IsToolbarVisible()
     {
-        // Always disable when visiting the aesthetician.
-        if (_condition[ConditionFlag.CreatingCharacter]) return false;
-
-        // Always disable when playing Air Force One in the Gold Saucer.
-        if (GameMain.Instance()->CurrentTerritoryIntendedUseId == TerritoryIntendedUse.AirForceOne) return false;
-
-        if (_clientState.IsGPosing && !ShowToolbarInGPose) return false;
-
-        if (_gameGui.GameUiHidden && !ShowToolbarOnUserHide) return false;
-
-        if (_player.IsInCutscene && !ShowToolbarInCutscenes) return false;
-
-        if (_player.IsBetweenAreas && !ShowToolbarBetweenAreas) return false;
-
-        if (_player.IsInIdleCam && !ShowToolbarDuringIdleCam) return false;
-
-        if (_player.IsInCombat && !ShowToolbarInCombat) return false;
-
-        if (_player.IsBoundByDuty && !ShowToolbarInDuty) return false;
-
-        if (RaptureAtkUnitManager.Instance()->IsEditingHudLayout && !ShowToolbarInHudEditing) return false;
-
-        return true;
+        if (!_visibilityCacheValid) ComputeVisibilityCache();
+        return _cachedToolbarVisible;
     }
 
     public unsafe bool AreMarkersVisible()
     {
-        // Always disable when visiting the aesthetician.
-        if (_condition[ConditionFlag.CreatingCharacter]) return false;
+        if (!_visibilityCacheValid) ComputeVisibilityCache();
+        return _cachedMarkersVisible;
+    }
 
-        // Always disable markers when in PvP.
-        if (_player.IsInPvP) return false;
+    private unsafe void ComputeVisibilityCache()
+    {
+        _visibilityCacheValid = true;
 
-        // Always disable when playing Air Force One in the Gold Saucer.
-        if (GameMain.Instance()->CurrentTerritoryIntendedUseId == TerritoryIntendedUse.AirForceOne) return false;
+        // 美容師訪問中は常に非表示
+        if (_condition[ConditionFlag.CreatingCharacter]) {
+            _cachedToolbarVisible = false;
+            _cachedMarkersVisible = false;
+            return;
+        }
 
-        if (_clientState.IsGPosing && !ShowMarkersInGPose) return false;
+        bool isInAirForceOne = GameMain.Instance()->CurrentTerritoryIntendedUseId == TerritoryIntendedUse.AirForceOne;
+        bool isGPosing       = _clientState.IsGPosing;
+        bool isUiHidden      = _gameGui.GameUiHidden;
+        bool isInCutscene    = _player.IsInCutscene;
+        bool isBetweenAreas  = _player.IsBetweenAreas;
+        bool isInIdleCam     = _player.IsInIdleCam;
+        bool isInCombat      = _player.IsInCombat;
+        bool isBoundByDuty   = _player.IsBoundByDuty;
+        bool isEditingHud    = RaptureAtkUnitManager.Instance()->IsEditingHudLayout;
+        bool isInPvP         = _player.IsInPvP;
 
-        if (_gameGui.GameUiHidden && !ShowMarkersOnUserHide) return false;
+        _cachedToolbarVisible =
+            !isInAirForceOne                                 &&
+            !(isGPosing      && !ShowToolbarInGPose)         &&
+            !(isUiHidden     && !ShowToolbarOnUserHide)      &&
+            !(isInCutscene   && !ShowToolbarInCutscenes)     &&
+            !(isBetweenAreas && !ShowToolbarBetweenAreas)    &&
+            !(isInIdleCam    && !ShowToolbarDuringIdleCam)   &&
+            !(isInCombat     && !ShowToolbarInCombat)        &&
+            !(isBoundByDuty  && !ShowToolbarInDuty)          &&
+            !(isEditingHud   && !ShowToolbarInHudEditing);
 
-        if (_player.IsInCutscene && !ShowMarkersInCutscenes) return false;
-
-        if (_player.IsBetweenAreas && !ShowMarkersBetweenAreas) return false;
-
-        if (_player.IsInIdleCam && !ShowMarkersDuringIdleCam) return false;
-
-        if (_player.IsInCombat && !ShowMarkersInCombat) return false;
-
-        if (_player.IsBoundByDuty && !ShowMarkersInDuty) return false;
-
-        return true;
+        _cachedMarkersVisible =
+            !isInPvP                                         &&
+            !isInAirForceOne                                 &&
+            !(isGPosing      && !ShowMarkersInGPose)         &&
+            !(isUiHidden     && !ShowMarkersOnUserHide)      &&
+            !(isInCutscene   && !ShowMarkersInCutscenes)     &&
+            !(isBetweenAreas && !ShowMarkersBetweenAreas)    &&
+            !(isInIdleCam    && !ShowMarkersDuringIdleCam)   &&
+            !(isInCombat     && !ShowMarkersInCombat)        &&
+            !(isBoundByDuty  && !ShowMarkersInDuty);
     }
 }

--- a/Umbra/src/Windows/Library/VariableEditor/VariablesEditorWindow.cs
+++ b/Umbra/src/Windows/Library/VariableEditor/VariablesEditorWindow.cs
@@ -52,7 +52,7 @@ public class VariablesEditorWindow(string title, List<Variable> variables, List<
     {
         base.OnDraw();
 
-        foreach (var (node, variable) in _variableNodes) {
+        foreach (var (node, variable) in _variableNodes.ToArray()) {
             node.Style.IsVisible = variable.DisplayIf?.Invoke() ?? true;
         }
     }

--- a/Umbra/src/Windows/Library/VariableEditor/VariablesEditorWindow.cs
+++ b/Umbra/src/Windows/Library/VariableEditor/VariablesEditorWindow.cs
@@ -212,7 +212,7 @@ public class VariablesEditorWindow(string title, List<Variable> variables, List<
         node.SupportsScripting = variable.SupportsScripting;
         
         node.OnValueChanged   += (v) => variable.Value = v;
-        variable.ValueChanged += (v) => variable.Value = v;
+        variable.ValueChanged += (v) => node.Value     = v;
 
         _variableNodes[node] = variable;
 
@@ -231,7 +231,7 @@ public class VariablesEditorWindow(string title, List<Variable> variables, List<
         );
 
         node.OnValueChanged   += (v) => variable.Value = v;
-        variable.ValueChanged += (v) => variable.Value = v;
+        variable.ValueChanged += (v) => node.Value     = v;
 
         _variableNodes[node] = variable;
 

--- a/Umbra/src/Windows/WindowManager.cs
+++ b/Umbra/src/Windows/WindowManager.cs
@@ -41,9 +41,13 @@ public class WindowManager(UmbraDelvClipRects delvClipRects) : IDisposable
 
                 window.RequestClose += () => {
                     delvClipRects.RemoveClipRect($"Umbra.Window.{id}");
-                    _callbacks[id]?.Invoke(window);
-                    _instances.Remove(id);
-                    _callbacks.Remove(id);
+                    Action<IWindow>? callback;
+                    lock (_instances) {
+                        _callbacks.TryGetValue(id, out callback);
+                        _instances.Remove(id);
+                        _callbacks.Remove(id);
+                    }
+                    callback?.Invoke(window);
                     OnWindowClosed?.Invoke(window);
                 };
 

--- a/Umbra/src/Windows/WindowManager.cs
+++ b/Umbra/src/Windows/WindowManager.cs
@@ -18,8 +18,8 @@ public class WindowManager(UmbraDelvClipRects delvClipRects) : IDisposable
 
         _instances.Clear();
 
-        foreach (var handler in OnWindowOpened?.GetInvocationList() ?? []) OnWindowOpened -= (Action<IWindow>)handler;
-        foreach (var handler in OnWindowClosed?.GetInvocationList() ?? []) OnWindowClosed -= (Action<IWindow>)handler;
+        OnWindowOpened = null;
+        OnWindowClosed = null;
     }
 
     /// <summary>
@@ -79,15 +79,22 @@ public class WindowManager(UmbraDelvClipRects delvClipRects) : IDisposable
     {
         bool hasFocusedWindow = false;
 
+        // スナップショットを取得してからロック外でレンダリングすることで、
+        // Framework.Run() による非同期追加との競合を避ける
+        List<KeyValuePair<string, IWindow>> snapshot;
         lock (_instances) {
-            foreach ((string id, IWindow window) in _instances) {
-                window.Render(id);
-                
-                if (window.IsFocused) hasFocusedWindow = true;
-                if (!window.IsClosed) delvClipRects.SetClipRect($"Umbra.Window.{id}", window.Position, window.Size);
-            }
+            snapshot = [.._instances];
         }
-        
+
+        foreach (var (id, window) in snapshot) {
+            if (window.IsClosed) continue;
+
+            window.Render(id);
+
+            if (window.IsFocused) hasFocusedWindow = true;
+            if (!window.IsClosed) delvClipRects.SetClipRect($"Umbra.Window.{id}", window.Position, window.Size);
+        }
+
         HasFocusedWindow = hasFocusedWindow;
     }
 }


### PR DESCRIPTION
## Summary

- **`AuxBarManager`**: Replaced per-frame LINQ + `ToList()` in `VisibleAuxBarPanels` with a pre-allocated list that is cleared and reused each frame.
- **`Toolbar`**: Added `_cachedIsCursorNear` field so `IsCursorNearToolbar()` is called exactly once per frame instead of multiple times across `UpdateToolbarNodeClassList()`, `UpdateToolbarAutoHideOffset()`, and `Toolbar.Nodes.cs`.
- **`Toolbar.Autohide`**: Cached `ImGui.GetIO()` to a local variable to avoid multiple P/Invoke calls per frame; inlined the `IsMultiMonitorSupportEnabled()` helper.
- **`Toolbar.Nodes`**: Cached `ImGui.GetMainViewport()` to a local variable inside `RenderAuxBarNodes()`; removed the redundant `auxBarNode.ComputeBoundingSize()` call (bounds are already computed inside `Render()`); removed two unused `using` directives; expanded `ToolbarXPosition` / `ToolbarYPosition` to block-body properties so the viewport is fetched once per call.
- **`ToolbarWidget` / `WidgetManager`**: Cached `ImGui.GetIO()` to a local variable where it was called multiple times in the same scope; replaced `GetInvocationList()` unsubscribe loops with direct `= null` assignments.
- **`UmbraVisibility`**: Introduced a frame-scoped validity flag (`_visibilityCacheValid`) reset via `[OnDraw(executionOrder: int.MinValue)]`; `IsToolbarVisible()` and `AreMarkersVisible()` now call the underlying checks at most once per frame and return cached results on subsequent calls.
- **`WindowManager`**: Replaced `GetInvocationList()` unsubscribe loops with direct `= null` assignments; moved window iteration outside the lock to reduce contention.

## Related

This PR covers only changes to the Umbra layer. Companion optimizations in the `Una.Drawing` library are submitted separately in [una-xiv/drawing#25](https://github.com/una-xiv/drawing/pull/25).