### PR TITLE
Implement viewport size check in CompassRenderer

### DIFF
--- a/Umbra/src/Markers/System/Compass/CompassRenderer.cs
+++ b/Umbra/src/Markers/System/Compass/CompassRenderer.cs
@@ -50,8 +50,10 @@ internal sealed class CompassRenderer(
         uint    iconColor = (0xFFFFFFFFu).ApplyAlphaComponent(IconOpacity / 100f);
         Vector2 vpSize    = ImGui.GetMainViewport().Size;
         Vector2 workPos   = ImGui.GetMainViewport().WorkPos;
+        vpSize.X -= clampSize;
+        vpSize.Y -= clampSize;
 
-        if ((vpSize.X - clampSize) <= float.Epsilon || (vpSize.Y - clampSize) <= float.Epsilon) return; // early return if viewport size somehow is smaller than the clampSize
+        if (vpSize.X <= float.Epsilon || vpSize.Y <= float.Epsilon) return; // early return if viewport size somehow is smaller than the clampSize
 
         if (!gameCamera.WorldToScreen(player.Position, out Vector2 playerScreenPosition)) return;
 
@@ -74,8 +76,8 @@ internal sealed class CompassRenderer(
             Vector2 iconPos   = playerScreenPosition + direction * CompassRadius;
 
             // Clamp the icon position to the screen bounds.
-            iconPos.X = Math.Clamp(iconPos.X, clampSize, vpSize.X - clampSize);
-            iconPos.Y = Math.Clamp(iconPos.Y, clampSize, vpSize.Y - clampSize);
+            iconPos.X = Math.Clamp(iconPos.X, clampSize, vpSize.X);
+            iconPos.Y = Math.Clamp(iconPos.Y, clampSize, vpSize.Y);
 
             Vector2 p1 = iconPos - new Vector2(iconSize / 2) + workPos;
             Vector2 p2 = iconPos + new Vector2(iconSize / 2) + workPos;

--- a/Umbra/src/Markers/System/Compass/CompassRenderer.cs
+++ b/Umbra/src/Markers/System/Compass/CompassRenderer.cs
@@ -51,6 +51,8 @@ internal sealed class CompassRenderer(
         Vector2 vpSize    = ImGui.GetMainViewport().Size;
         Vector2 workPos   = ImGui.GetMainViewport().WorkPos;
 
+        if ((vpSize.X - clampSize) <= float.Epsilon || (vpSize.Y - clampSize) <= float.Epsilon) return; // early return if viewport size somehow is smaller than the clampSize
+
         if (!gameCamera.WorldToScreen(player.Position, out Vector2 playerScreenPosition)) return;
 
         playerScreenPosition.X += CenterPointXOffset;


### PR DESCRIPTION
Adds early return to if `vpSize`  is less than `clampSize`