### PR TITLE
Resolve UDT from multiple assemblies

### DIFF
--- a/Umbra/src/Plugins/Plugin.cs
+++ b/Umbra/src/Plugins/Plugin.cs
@@ -38,6 +38,7 @@ internal class Plugin : IDisposable
             Assembly = _context.LoadFromFile(File.FullName);
 
             Framework.Assemblies.Add(Assembly);
+            UdtLoader.AddAssembly(Assembly);
         } catch (Exception e) {
             Entry.LoadError = e.Message;
             Dispose();
@@ -49,6 +50,7 @@ internal class Plugin : IDisposable
     {
         if (Assembly != null) {
             Framework.Assemblies.Remove(Assembly);
+            UdtLoader.RemoveAssembly(Assembly);
         }
 
         _context?.Unload();

--- a/Umbra/src/Plugins/PluginLoadContext.cs
+++ b/Umbra/src/Plugins/PluginLoadContext.cs
@@ -28,16 +28,18 @@ internal class PluginLoadContext(DirectoryInfo directoryInfo) : AssemblyLoadCont
         foreach (var name in assembly.GetReferencedAssemblies()) {
             if (null == name.Name || !KnownAssemblies.TryGetValue(name.Name, out var referencedKnownAssembly)) continue;
 
-            if (name.Name == "Umbra") hasUmbraReference = true;
+            // Allow any of the following references to be seen as a valid Umbra plugin.
+            hasUmbraReference = name.Name switch {
+                "Umbra" or "Umbra.Common" or "Umbra.Game" => true,
+                _                                         => hasUmbraReference,
+            };
 
             ValidateReferencedAssembly(name, referencedKnownAssembly.GetName());
         }
 
-        if (!hasUmbraReference) {
-            throw new ("This is not an Umbra plugin.");
-        }
-
-        return assembly;
+        return !hasUmbraReference
+            ? throw new($"The plugin \"{filePath}\" is not a valid Umbra plugin.")
+            : assembly;
     }
 
     private Assembly LoadFromFileInternal(string filePath)
@@ -84,7 +86,8 @@ internal class PluginLoadContext(DirectoryInfo directoryInfo) : AssemblyLoadCont
 
         if (usedMa < refMa || usedMi < refMi) {
             // I18N isn't available here.
-            throw new ($"This plugin cannot be loaded because it was made using {refAsm.Name} version {usedMa}.{usedMi}, but {refMa}.{refMi} is required. This plugin should be updated by the author.");
+            throw new(
+                $"This plugin cannot be loaded because it was made using {refAsm.Name} version {usedMa}.{usedMi}, but {refMa}.{refMi} is required. This plugin should be updated by the author.");
         }
     }
 }

--- a/Umbra/src/Umbra.Drawing.cs
+++ b/Umbra/src/Umbra.Drawing.cs
@@ -17,11 +17,15 @@ internal static class UmbraDrawing
 
         UdtLoader.RegisterAttributeValueParser(new I18NAttributeValueParser());
         UdtLoader.RegisterDirectiveParser(new ImageSourceDirectiveParser());
-        
-        UdtDocument doc = UdtLoader.LoadFromAssembly(Assembly.GetExecutingAssembly(), "umbra.globals.xml");
-        
+
+        foreach (var assembly in Framework.Assemblies) {
+            UdtLoader.AddAssembly(assembly);
+        }
+
+        UdtDocument doc = UdtLoader.Load("umbra.globals.xml");
+
         StylesheetRegistry.Register("globals", doc.Stylesheet!);
-        
+
         ElementRegistry.Register<ButtonNode>();
         ElementRegistry.Register<CheckboxNode>();
         ElementRegistry.Register<ColorInputNode>();
@@ -45,31 +49,24 @@ internal static class UmbraDrawing
         DrawingLib.Dispose();
     }
 
+    /// <summary>
+    /// Deprecated. Use <see cref="UdtLoader.Load"/> instead.
+    /// </summary>
     internal static UdtDocument DocumentFrom(string resourceName)
     {
-        foreach (var assembly in Framework.Assemblies) {
-            var resource = assembly
-                          .GetManifestResourceNames()
-                          .FirstOrDefault(r => r.EndsWith(resourceName, StringComparison.OrdinalIgnoreCase));
-            
-            if (resource == null) continue;
-            
-            return UdtLoader.LoadFromAssembly(assembly, resourceName);
-        }
-        
-        throw new Exception($"No UDT document with the name \"{resourceName}\" exists in any assembly.");
+        return UdtLoader.Load(resourceName);
     }
-    
+
     /// <summary>
     /// Sets the image bytes of a node from an embedded resource.
     /// </summary>
     /// <param name="node"></param>
     /// <param name="resourceName"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    internal static void SetImageFromResource(this Node node, string resourceName)
+    public static void SetImageFromResource(this Node node, string resourceName)
     {
         resourceName = resourceName.ToLowerInvariant();
-        
+
         foreach (var asm in Framework.Assemblies) {
             foreach (var name in asm.GetManifestResourceNames()) {
                 if (name.ToLowerInvariant().EndsWith(resourceName)) {

--- a/Umbra/src/Umbra.Plugin.cs
+++ b/Umbra/src/Umbra.Plugin.cs
@@ -40,10 +40,10 @@ internal sealed class Plugin : IDalamudPlugin
         PluginInterface = plugin;
         plugin.Inject(this);
 
+        RegisterServices();
+
         UmbraDrawing.Initialize(plugin);
         Node.UseThreadedStyleComputation = true;
-
-        RegisterServices();
 
         ClientState.Login  += OnLogin;
         ClientState.Logout += OnLogout;

--- a/Umbra/src/Windows/Library/Settings/SettingsWindowModule.cs
+++ b/Umbra/src/Windows/Library/Settings/SettingsWindowModule.cs
@@ -41,7 +41,7 @@ public abstract class SettingsWindowModule
 
     internal void Activate(Node contentNode)
     {
-        Document = UdtLoader.LoadFromAssembly(Assembly.GetExecutingAssembly(), UdtResourceName);
+        Document = UdtLoader.Load(UdtResourceName);
         RootNode = Document.RootNode ??
                    throw new Exception($"The UDT resource \"{UdtResourceName}\" does not contain a root node.");
 
@@ -53,9 +53,9 @@ public abstract class SettingsWindowModule
     internal void Deactivate()
     {
         if (RootNode == null!) return;
-        
+
         OnClose();
-        
+
         RootNode.Dispose();
         RootNode = null!;
         Document = null!;


### PR DESCRIPTION
The main reason for this entire change is to allow referencing UDT files from other assemblies / Umbra Plugins.

With this change, the following is now allowed in plugin code:

```cs
using Umbra.Windows.Settings;

namespace Umbra.Frames.Settings;

public class SettingsWindow : SettingsWindowModule
{
    public override    string Name            => "Frames";
    public override    int    Order           => 10;
    protected override string UdtResourceName => "frames.settings.xml";
}
```

<img width="775" height="164" alt="image" src="https://github.com/user-attachments/assets/035eb459-60c6-4f5a-a97c-709650199eee" />


Because `SettingsWindowModule` lives in Umbra itself, Umbra used to use the `UdtLoader.LoadFromAssembly` method to load the XML file. Now it properly scans for registered assemblies and find the one embedded in plugin assemblies as well.

As an added benefit, plugins can now freely import UDT resources from Umbra to reuse existing UDT-components (layouts, templates, etc.)
