### PR TITLE
don't clear the dictionary as some indexes might not be already existing

### DIFF
--- a/Umbra/src/Toolbar/Widgets/System/WidgetManager.Config.cs
+++ b/Umbra/src/Toolbar/Widgets/System/WidgetManager.Config.cs
@@ -1,4 +1,4 @@
-﻿using Lumina.Excel.Sheets;
+using Lumina.Excel.Sheets;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
@@ -141,8 +141,6 @@ internal partial class WidgetManager
 
         var data2 = JsonConvert.DeserializeObject<Dictionary<byte, string>>(JobToProfileData);
         if (data2 is null) return;
-
-        JobToProfileName.Clear();
 
         foreach ((byte job, string profile) in data2) {
             JobToProfileName[job] = _widgetProfiles.ContainsKey(profile) ? profile : "Default";


### PR DESCRIPTION
Fixes the issue of:

```
18:58:16.568 | ERR | Unobserved exception in Task.
    System.AggregateException: A Task's exception(s) were not observed either by Waiting on the Task or accessing its Exception property. As a result, the unobserved exception was rethrown by the finalizer thread. (Exception has been thrown by the target of an invocation.)
     ---> System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
     ---> System.Collections.Generic.KeyNotFoundException: The given key '43' was not present in the dictionary.
       at Umbra.Widgets.System.WidgetManager.OnUpdateWidgets() in /work/repo/Umbra/src/Toolbar/Widgets/System/WidgetManager.cs:line 309
       at InvokeStub_WidgetManager.OnUpdateWidgets(Object, Object, IntPtr*)
       at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
       --- End of inner exception stack trace ---
       at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
       at Umbra.Common.Scheduler.TickHandler.Invoke(Double deltaTime) in /work/repo/Umbra.Common/src/Scheduler/Scheduler.cs:line 180
       at Umbra.Common.Scheduler.<>c__DisplayClass20_0.<OnUmbraTick>b__0() in /work/repo/Umbra.Common/src/Scheduler/Scheduler.cs:line 86
       at Dalamud.Game.Framework.RunOnFrameworkThread(Action action) in /_/Dalamud/Game/Framework.cs:line 178
       --- End of inner exception stack trace ---
```

This is due to `Toolbar.JobToProfile` having a valid JSON format where the key value pair is missing index 43, 44, and 45 which will cause issues in Evercold also due to index 44, and 45. Index 43 is Beastmaster which released with 7.56 which started this bug.